### PR TITLE
Remove SIDs/STARs that serve the wrong airports from consideration

### DIFF
--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooser.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooser.java
@@ -92,7 +92,7 @@ final class GraphicalRouteChooser implements RouteChooser {
         .map(Fix::fixIdentifier)
         .toList();
 
-    List<String> exitNames = resolvedEntryPoints.stream()
+    List<String> exitNames = resolvedExitPoints.stream()
         .map(Leg::associatedFix)
         .flatMap(Optional::stream)
         .map(Fix::fixIdentifier)

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooserTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooserTest.java
@@ -108,7 +108,7 @@ class GraphicalRouteChooserTest {
     Leg l3 = TF("GRRDR", 0.0, 2.0);
     Leg l4 = TF("VNY", 0.0, 3.0);
 
-    Transition t = transition("BLSTR1", TransitionType.COMMON, ProcedureType.SID, Arrays.asList(l1, l2, l3, l4));
+    Transition t = transition("BLSTR1", "KIND", TransitionType.COMMON, ProcedureType.SID, Arrays.asList(l1, l2, l3, l4));
 
     return RouteTokenResolver.standard(
         LookupService.inMemory(singletonList(kind), a -> Stream.of(a.airportIdentifier())),

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
@@ -66,6 +66,25 @@ import org.mitre.tdp.boogie.alg.split.Wildcard;
 class FluentRouteExpanderTest {
 
   @Test
+  void ffice() {
+    String route = "VDPP..PNH.M755.KISAN.M755.TUNPO.M755.BITOD.M753.IPRIX.M753.ENREP.N891.UGPEK.N891.URIGO.N891.MANIM.N891.OBDAB..PIBAP..PASPU.LEBA2A.WSSS";
+    FluentRouteExpander expander = newExpander(
+            List.of(anito),
+            emptyList(),
+            List.of(Airports.WSSS()),
+            List.of(CHA1C_WSSS_PARTIAL.INSTANCE)
+    );
+    ExpandedRoute expandedRoute = expander.apply(route, "RW02", null).orElseThrow();
+    List<ExpandedRouteLeg> legs = expandedRoute.legs();
+    ExpandedRoute two = expander.apply(route, "RW03", null).orElseThrow();
+    List<ExpandedRouteLeg> legs2 = two.legs();
+    assertAll(
+            () -> assertEquals(6, legs.size(), "Should be: WSSS -> VA -> VM -> WSSS -> FIX -> FIX"),
+            () -> assertEquals(6, legs2.size(), "Same thing but with an FM leg")
+    );
+  }
+
+  @Test
   void testNoWeight() {
     String route = "WSSS.CHA1C.ANITO";
     Fix anito = fix("ANITO", -0.2833, 104.8667);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6e158239-7f33-4dcc-bd26-97c3b1a547df)

It is currently possible for the resolved tokens to get into a bad state when there is a SID and a STAR at different airports that share a name. This leads to routes like:
```
VDPP..PNH.M755.KISAN.M755.TUNPO.M755.BITOD.M753.IPRIX.M753.ENREP.N891.UGPEK.N891.URIGO.N891.MANIM.N891.OBDAB..PIBAP..PASPU.LEBA2A.WSSS
```
to get messed up because `PASPU` is linked to a leg on the LRBV SID named `LEBA2A` and then to the WSSS STAR named `LEBA2A`.

This PR ensures that only SIDs/STARs serving the departure/arrival airports can be considered when finding a route.