### PR TITLE
Drop a section under specific circumstances

### DIFF
--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/RouteExpander.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/RouteExpander.java
@@ -7,22 +7,30 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.mitre.caasd.commons.collect.HashedLinkedSequence.newHashedLinkedSequence;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 import org.mitre.caasd.commons.collect.HashedLinkedSequence;
+import org.mitre.tdp.boogie.Procedure;
+import org.mitre.tdp.boogie.Transition;
+import org.mitre.tdp.boogie.TransitionType;
 import org.mitre.tdp.boogie.alg.chooser.RouteChooser;
 import org.mitre.tdp.boogie.alg.chooser.graph.TokenMapper;
 import org.mitre.tdp.boogie.alg.facade.FluentRouteExpander;
 import org.mitre.tdp.boogie.alg.resolve.ResolvedToken;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedTokenVisitor;
 import org.mitre.tdp.boogie.alg.resolve.ResolvedTokens;
 import org.mitre.tdp.boogie.alg.resolve.RouteTokenResolver;
 import org.mitre.tdp.boogie.alg.resolve.infer.SectionInferrer;
 import org.mitre.tdp.boogie.alg.split.RouteToken;
 import org.mitre.tdp.boogie.alg.split.RouteTokenizer;
+import org.mitre.tdp.boogie.util.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
 
 /**
  * Core interface for the functional definition of a route expander in Boogie.
@@ -104,8 +112,43 @@ public interface RouteExpander {
           .sorted(comparingDouble(r -> r.routeToken().index()))
           .toList();
 
-      return routeChooser.chooseRoute(logResolvedTokens(sortedByIndex));
+      logResolvedTokens(sortedByIndex);
+
+      List<ResolvedTokens> noEmpty = reduceEmptyProcedureTokens(sortedByIndex);
+
+      return routeChooser.chooseRoute(noEmpty);
     }
+
+    /**
+     * In rare cases when procedure names overlap and the transition types of those collisions are such that they could
+     * be combined into a route (even though probably on the other side of the planet) ... we don't want to have an
+     * e.g., inferred star runway transition and then get that linked somehow to some other procedures common
+     * @param routeTokens all the tokens
+     * @return with the ResolvedTokens item dropped if its a resolved + inferred pair but the resolved has no maked transitions left.
+     */
+    private static List<ResolvedTokens> reduceEmptyProcedureTokens(List<ResolvedTokens> routeTokens) {
+      List<ResolvedTokens> mutable = new ArrayList<>();
+      Streams.pairwise(routeTokens, STAR_COLLAPSE).filter(Objects::nonNull).forEach(mutable::add);
+      mutable.add(routeTokens.get(routeTokens.size() - 1));
+      return List.copyOf(mutable);
+    }
+
+    private static final BiFunction<ResolvedTokens, ResolvedTokens, ResolvedTokens> STAR_COLLAPSE = (f,s) -> {
+      Set<Procedure> emptyStars = f.resolvedTokens().stream()
+          .map(ResolvedTokenVisitor::star)
+          .flatMap(Optional::stream)
+          .filter(star -> star.transitions().isEmpty())
+          .collect(Collectors.toSet());
+
+
+
+
+      if (starsA.stream().anyMatch(i -> i.transitions().isEmpty() && matchingAirports.contains(i.airportIdentifier()))) {
+        return null;
+      }
+
+      return f;
+    };
 
     private static void appendInferredSections(HashedLinkedSequence<ResolvedTokens> sequence, SectionInferrer inferrer) {
       inferrer.inferAcross(sequence).forEach((start, inferred) -> {
@@ -134,7 +177,7 @@ public interface RouteExpander {
       return routeTokens;
     }
 
-    private static List<ResolvedTokens> logResolvedTokens(List<ResolvedTokens> resolvedTokens) {
+    private void logResolvedTokens(List<ResolvedTokens> resolvedTokens) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("- ResolvedTokens: {}", resolvedTokens.stream().mapToInt(tokens -> tokens.resolvedTokens().size()).sum());
         LOG.debug(String.format("  %10s %50s", "Identifier", "Types"));
@@ -147,7 +190,6 @@ public interface RouteExpander {
             )
         );
       }
-      return resolvedTokens;
     }
 
     public static final class Builder {

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/ResolvedTokenReducer.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/ResolvedTokenReducer.java
@@ -1,0 +1,82 @@
+package org.mitre.tdp.boogie.alg.resolve;
+
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.mitre.tdp.boogie.Procedure;
+import org.mitre.tdp.boogie.TransitionType;
+
+/**
+ * This class takes pairs or resolved tokens and collapses them in rare cases where transition structure results in
+ * the wrong token being used by the route choosers down stream.
+ * <p>
+ * This happens when there are two tokens with the same name, but a transition masked procedure has one with transitions.
+ */
+public final class ResolvedTokenReducer implements BiFunction<ResolvedTokens, ResolvedTokens, ResolvedTokens>, Serializable {
+  public static final ResolvedTokenReducer INSTANCE = new ResolvedTokenReducer();
+
+  /**
+   * If the first token is a star with no transitions, then if matches with the inferred section ... don't keep this
+   */
+  private static final BiFunction<ResolvedTokens, ResolvedTokens, Optional<ResolvedTokens>> POSSIBLY_KEEP_STAR = (first, second) -> {
+    Optional<Procedure> resolvedStarNoTransitions = first.resolvedTokens().stream()
+        .map(ResolvedTokenVisitor::star)
+        .flatMap(Optional::stream)
+        .filter(star -> star.transitions().isEmpty())
+        .findFirst();
+
+    Optional<Procedure> matchingInferredStar = resolvedStarNoTransitions.flatMap(r -> second.resolvedTokens().stream()
+        .map(ResolvedTokenVisitor::star)
+        .flatMap(Optional::stream)
+        .filter(star -> star.transitions().stream().anyMatch(i -> TransitionType.RUNWAY.equals(i.transitionType())))
+        .findFirst()
+        .filter(i -> i.procedureIdentifier().equals(r.procedureIdentifier()))
+    );
+
+    if (matchingInferredStar.isPresent()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(first);
+  };
+
+  private static final BiFunction<ResolvedTokens, ResolvedTokens, Optional<ResolvedTokens>> POSSIBLY_KEEP_SID = (first, second) -> {
+    Optional<Procedure> resolvedSidNoTransitions = second.resolvedTokens().stream()
+        .map(ResolvedTokenVisitor::sid)
+        .flatMap(Optional::stream)
+        .filter(star -> star.transitions().isEmpty())
+        .findFirst();
+
+    Optional<Procedure> matchingInferredSid = resolvedSidNoTransitions.flatMap(r -> first.resolvedTokens().stream()
+        .map(ResolvedTokenVisitor::sid)
+        .flatMap(Optional::stream)
+        .filter(star -> star.transitions().stream().anyMatch(i -> TransitionType.RUNWAY.equals(i.transitionType())))
+        .findFirst()
+        .filter(i -> i.procedureIdentifier().equals(r.procedureIdentifier()))
+    );
+
+    if (matchingInferredSid.isPresent()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(second);
+  };
+
+  /**
+   * This means that we only have one resolved token or the infrastructure names don't overlap so no worries with this pairing
+   */
+  private static final BiFunction<ResolvedTokens, ResolvedTokens, Optional<ResolvedTokens>> KEEP_WHEN_NO_OVERLAP = (f, s) -> Optional.of(f)
+      .filter(first -> f.resolvedTokens().size() <= 1 || !f.routeToken().infrastructureName().equals(s.routeToken().infrastructureName()));
+
+
+  private ResolvedTokenReducer(){}
+
+  @Override
+  public ResolvedTokens apply(ResolvedTokens f, ResolvedTokens s) {
+    return KEEP_WHEN_NO_OVERLAP.apply(f, s)
+        .or(() -> POSSIBLY_KEEP_STAR.apply(f, s))
+        .or(() -> POSSIBLY_KEEP_SID.apply(f, s))
+        .orElse(null);
+  }
+}

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/SidResolver.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/SidResolver.java
@@ -45,12 +45,12 @@ final class SidResolver implements RouteTokenResolver {
 
     Collection<Procedure> sids = lookupService.apply(current.infrastructureName());
 
-    Collection<Procedure> fromArrivalAirport = sids.stream()
-        .filter(p -> isFromArrivalAirport(p, previous))
+    Collection<Procedure> fromDepartureAirport = sids.stream()
+        .filter(p -> isFromDepartureAirport(p, previous))
         .collect(toList());
 
-    if (!fromArrivalAirport.isEmpty()) {
-      return fromArrivalAirport;
+    if (!fromDepartureAirport.isEmpty()) {
+      return fromDepartureAirport;
     }
 
     Collection<Procedure> containingExitFix = sids.stream()
@@ -65,7 +65,7 @@ final class SidResolver implements RouteTokenResolver {
   }
 
   /**
-   * Returns true if the provided procedure is for an airport matching the candidate "arrival airport" token.
+   * Returns true if the provided procedure is for an airport matching the candidate "departure airport" token.
    *
    * <p>Often navigation databases will contain copies of the same procedure serving different satellite airports around a major
    * one, this helps ensure we select the correct one.
@@ -73,7 +73,7 @@ final class SidResolver implements RouteTokenResolver {
    * <p>e.g. HOBBT2 serves KATL, SATELLITE1, SATELLITE2... we get a copy of HOBBT2 in the raw data for each of those airports, this
    * is mean't to prefer the implementation who's {@link Procedure#airportIdentifier()} matches the filed arrival/departure airport.
    */
-  private boolean isFromArrivalAirport(Procedure procedure, @Nullable RouteToken previous) {
+  private boolean isFromDepartureAirport(Procedure procedure, @Nullable RouteToken previous) {
     return ofNullable(previous)
         .filter(p -> p.infrastructureName().equalsIgnoreCase(procedure.airportIdentifier()))
         .isPresent();

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/TestGraphicalRouteExpander.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/TestGraphicalRouteExpander.java
@@ -5,20 +5,17 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mitre.tdp.boogie.Airports.KDEN;
-import static org.mitre.tdp.boogie.MockObjects.fix;
+import static org.mitre.tdp.boogie.MockObjects.*;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-import org.mitre.tdp.boogie.Airport;
-import org.mitre.tdp.boogie.Airway;
-import org.mitre.tdp.boogie.CONNR5;
-import org.mitre.tdp.boogie.Fix;
-import org.mitre.tdp.boogie.PathTerminator;
-import org.mitre.tdp.boogie.Procedure;
+import org.mitre.caasd.commons.LatLong;
+import org.mitre.tdp.boogie.*;
 import org.mitre.tdp.boogie.alg.facade.ExpandedRoute;
 import org.mitre.tdp.boogie.alg.facade.ExpandedRouteLeg;
 import org.mitre.tdp.boogie.alg.facade.FluentRouteExpander;
@@ -30,6 +27,70 @@ import com.google.common.collect.Lists;
  * level class.
  */
 class TestGraphicalRouteExpander {
+  static FluentRouteExpander wsssExpander() {
+    Airport wsss = MockObjects.airport("WSSS", 0.0, 6.0);
+
+    Fix bv413 = Fix.builder().fixIdentifier("BV413").latLong(LatLong.of(5.0, 5.0)).build();
+    Fix bv414 = Fix.builder().fixIdentifier("BV414").latLong(LatLong.of(5.0, 6.0)).build();
+    Fix lebat = Fix.builder().fixIdentifier("LEBAT").latLong(LatLong.of(5.0, 7.0)).build();
+
+    Leg l10 = Leg.ifBuilder(bv413, 0).build();
+    Leg l11 = Leg.dfBuilder(bv414, 1).build();
+    Leg l12 = Leg.dfBuilder(lebat, 2).build();
+
+    Fix paspu = Fix.builder().fixIdentifier("PASPU").latLong(LatLong.of(0.0, 2.0)).build();
+    Fix pu = Fix.builder().fixIdentifier("PU").latLong(LatLong.of(0.0, 3.0)).build();
+    Fix sj = Fix.builder().fixIdentifier("SJ").latLong(LatLong.of(0.0, 4.0)).build();
+    Fix palga = Fix.builder().fixIdentifier("PALGA").latLong(LatLong.of(0.0, 5.0)).build();
+
+    Leg l2 = Leg.ifBuilder(paspu, 0).build();
+    Leg l3 = Leg.tfBuilder(pu, 1).build();
+    Leg l4 = Leg.tfBuilder(sj, 2).build();
+    Leg l5 = Leg.tfBuilder(palga, 3).build();
+
+    List<Leg> starLegs = List.of(l2, l3, l4, l5);
+    List<Leg> sidLegs = List.of(l10, l11, l12);
+
+    Transition sidTrans = Transition.builder()
+        .transitionIdentifier("ALL")
+        .transitionType(TransitionType.COMMON)
+        .legs(sidLegs)
+        .build();
+    Transition starTrans = Transition.builder()
+        .transitionIdentifier("RW02C")
+        .transitionType(TransitionType.RUNWAY)
+        .legs(starLegs)
+        .build();
+
+    Procedure sid = Procedure.builder()
+        .procedureIdentifier("LEBA2A")
+        .procedureType(ProcedureType.SID)
+        .transitions(List.of(sidTrans))
+        .airportIdentifier("OTHER")
+        .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
+        .build();
+
+    Procedure star = Procedure.builder()
+        .procedureIdentifier("LEBA2A")
+        .procedureType(ProcedureType.STAR)
+        .transitions(List.of(starTrans))
+        .airportIdentifier("WSSS")
+        .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
+        .build();
+
+    return FluentRouteExpander.inMemoryBuilder(List.of(wsss), List.of(sid, star), List.of(), List.of(paspu)).build();
+  }
+
+  @Test
+  void sameIdentTest() {
+    String route = "PASPU.LEBA2A.WSSS";
+    FluentRouteExpander expander = wsssExpander();
+    ExpandedRoute expandedRoute = expander.apply(route, null, "RW02C").orElseThrow();
+
+    assertAll("the same name but clearly different routes",
+        () -> assertEquals(5, expandedRoute.legs().size())
+    );
+  }
 
   @Test
   void testSubsequentDFToTFConverterIsAppliedWithinExpansion() {
@@ -52,7 +113,7 @@ class TestGraphicalRouteExpander {
         () -> assertEquals(PathTerminator.DF, legsByFix.get("WRIPS").pathTerminator(), "DF filed after VA as part of SID should be unchanged."));
   }
 
-  private FluentRouteExpander newExpander(
+  private static FluentRouteExpander newExpander(
       Collection<? extends Fix> fixes,
       Collection<? extends Airway> airways,
       Collection<? extends Airport> airports,

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/TestGraphicalRouteExpander.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/TestGraphicalRouteExpander.java
@@ -2,8 +2,7 @@ package org.mitre.tdp.boogie.alg.chooser;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mitre.tdp.boogie.Airports.KDEN;
 import static org.mitre.tdp.boogie.MockObjects.*;
 
@@ -16,6 +15,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.mitre.caasd.commons.LatLong;
 import org.mitre.tdp.boogie.*;
+import org.mitre.tdp.boogie.alg.chooser.graph.Expanders;
 import org.mitre.tdp.boogie.alg.facade.ExpandedRoute;
 import org.mitre.tdp.boogie.alg.facade.ExpandedRouteLeg;
 import org.mitre.tdp.boogie.alg.facade.FluentRouteExpander;
@@ -27,68 +27,32 @@ import com.google.common.collect.Lists;
  * level class.
  */
 class TestGraphicalRouteExpander {
-  static FluentRouteExpander wsssExpander() {
-    Airport wsss = MockObjects.airport("WSSS", 0.0, 6.0);
-
-    Fix bv413 = Fix.builder().fixIdentifier("BV413").latLong(LatLong.of(5.0, 5.0)).build();
-    Fix bv414 = Fix.builder().fixIdentifier("BV414").latLong(LatLong.of(5.0, 6.0)).build();
-    Fix lebat = Fix.builder().fixIdentifier("LEBAT").latLong(LatLong.of(5.0, 7.0)).build();
-
-    Leg l10 = Leg.ifBuilder(bv413, 0).build();
-    Leg l11 = Leg.dfBuilder(bv414, 1).build();
-    Leg l12 = Leg.dfBuilder(lebat, 2).build();
-
-    Fix paspu = Fix.builder().fixIdentifier("PASPU").latLong(LatLong.of(0.0, 2.0)).build();
-    Fix pu = Fix.builder().fixIdentifier("PU").latLong(LatLong.of(0.0, 3.0)).build();
-    Fix sj = Fix.builder().fixIdentifier("SJ").latLong(LatLong.of(0.0, 4.0)).build();
-    Fix palga = Fix.builder().fixIdentifier("PALGA").latLong(LatLong.of(0.0, 5.0)).build();
-
-    Leg l2 = Leg.ifBuilder(paspu, 0).build();
-    Leg l3 = Leg.tfBuilder(pu, 1).build();
-    Leg l4 = Leg.tfBuilder(sj, 2).build();
-    Leg l5 = Leg.tfBuilder(palga, 3).build();
-
-    List<Leg> starLegs = List.of(l2, l3, l4, l5);
-    List<Leg> sidLegs = List.of(l10, l11, l12);
-
-    Transition sidTrans = Transition.builder()
-        .transitionIdentifier("ALL")
-        .transitionType(TransitionType.COMMON)
-        .legs(sidLegs)
-        .build();
-    Transition starTrans = Transition.builder()
-        .transitionIdentifier("RW02C")
-        .transitionType(TransitionType.RUNWAY)
-        .legs(starLegs)
-        .build();
-
-    Procedure sid = Procedure.builder()
-        .procedureIdentifier("LEBA2A")
-        .procedureType(ProcedureType.SID)
-        .transitions(List.of(sidTrans))
-        .airportIdentifier("OTHER")
-        .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
-        .build();
-
-    Procedure star = Procedure.builder()
-        .procedureIdentifier("LEBA2A")
-        .procedureType(ProcedureType.STAR)
-        .transitions(List.of(starTrans))
-        .airportIdentifier("WSSS")
-        .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
-        .build();
-
-    return FluentRouteExpander.inMemoryBuilder(List.of(wsss), List.of(sid, star), List.of(), List.of(paspu)).build();
-  }
 
   @Test
-  void sameIdentTest() {
+  void sameIdentNoTransitions() {
+    FluentRouteExpander expander = Expanders.wsssExpander();
+
     String route = "PASPU.LEBA2A.WSSS";
-    FluentRouteExpander expander = wsssExpander();
     ExpandedRoute expandedRoute = expander.apply(route, null, "RW02C").orElseThrow();
 
-    assertAll("the same name but clearly different routes",
-        () -> assertEquals(5, expandedRoute.legs().size())
+    Map<String, Leg> legsByFix = expandedRoute.legs().stream()
+        .filter(leg -> leg.associatedFix().isPresent())
+        .collect(Collectors.toMap(leg -> leg.associatedFix().orElseThrow(IllegalStateException::new).fixIdentifier(), Function.identity()));
+
+    String route1 = "OTHER.LEBA2A.LEBAT";
+    ExpandedRoute expandedRoute1 = expander.apply(route1, "RW22", null).orElseThrow();
+
+    Map<String, Leg> legsByFix1 = expandedRoute1.legs().stream()
+        .filter(leg -> leg.associatedFix().isPresent())
+        .collect(Collectors.toMap(leg -> leg.associatedFix().orElseThrow(IllegalStateException::new).fixIdentifier(), Function.identity()));
+
+    assertAll("This used to resolve LEBA2A as a SID common into the STAR runway in case one ... oops",
+        () -> assertEquals(5, expandedRoute.legs().size(), "Would be 3 legs if the routes were built up wrong"),
+        () -> assertEquals(4, expandedRoute1.legs().size(), "Same 3 leg issue here if the route was wrong"),
+        () -> assertNotNull(legsByFix.get("PU"), "gets skipped if went to the star from the sid by mistake"),
+        () -> assertNotNull(legsByFix.get("SJ"), "gets skipped if went to the tar from teh sid by mistake"),
+        () -> assertNotNull(legsByFix1.get("LEBAT")),
+        () -> assertNotNull(legsByFix1.get("BV414"), "would get skipped if it tried to jump to the star")
     );
   }
 

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/graph/Expanders.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/graph/Expanders.java
@@ -1,0 +1,65 @@
+package org.mitre.tdp.boogie.alg.chooser.graph;
+
+import java.util.List;
+
+import org.mitre.caasd.commons.LatLong;
+import org.mitre.tdp.boogie.*;
+import org.mitre.tdp.boogie.alg.facade.FluentRouteExpander;
+
+public final class Expanders {
+
+    public static FluentRouteExpander wsssExpander() {
+      Airport wsss = MockObjects.airport("WSSS", 0.0, 6.0);
+      Airport other = MockObjects.airport("OTHER", 5.0, 4.0);
+
+      Fix bv413 = Fix.builder().fixIdentifier("BV413").latLong(LatLong.of(5.0, 5.0)).build();
+      Fix bv414 = Fix.builder().fixIdentifier("BV414").latLong(LatLong.of(5.0, 6.0)).build();
+      Fix lebat = Fix.builder().fixIdentifier("LEBAT").latLong(LatLong.of(5.0, 7.0)).build();
+
+      Leg l10 = Leg.ifBuilder(bv413, 0).build();
+      Leg l11 = Leg.dfBuilder(bv414, 1).build();
+      Leg l12 = Leg.dfBuilder(lebat, 2).build();
+
+      Fix paspu = Fix.builder().fixIdentifier("PASPU").latLong(LatLong.of(0.0, 2.0)).build();
+      Fix pu = Fix.builder().fixIdentifier("PU").latLong(LatLong.of(0.0, 3.0)).build();
+      Fix sj = Fix.builder().fixIdentifier("SJ").latLong(LatLong.of(0.0, 4.0)).build();
+      Fix palga = Fix.builder().fixIdentifier("PALGA").latLong(LatLong.of(0.0, 5.0)).build();
+
+      Leg l2 = Leg.ifBuilder(paspu, 0).build();
+      Leg l3 = Leg.tfBuilder(pu, 1).build();
+      Leg l4 = Leg.tfBuilder(sj, 2).build();
+      Leg l5 = Leg.tfBuilder(palga, 3).build();
+
+      List<Leg> starLegs = List.of(l2, l3, l4, l5);
+      List<Leg> sidLegs = List.of(l10, l11, l12);
+
+      Transition sidTrans = Transition.builder()
+          .transitionIdentifier("ALL")
+          .transitionType(TransitionType.COMMON)
+          .legs(sidLegs)
+          .build();
+      Transition starTrans = Transition.builder()
+          .transitionIdentifier("RW02C")
+          .transitionType(TransitionType.RUNWAY)
+          .legs(starLegs)
+          .build();
+
+      Procedure sid = Procedure.builder()
+          .procedureIdentifier("LEBA2A")
+          .procedureType(ProcedureType.SID)
+          .transitions(List.of(sidTrans))
+          .airportIdentifier("OTHER")
+          .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
+          .build();
+
+      Procedure star = Procedure.builder()
+          .procedureIdentifier("LEBA2A")
+          .procedureType(ProcedureType.STAR)
+          .transitions(List.of(starTrans))
+          .airportIdentifier("WSSS")
+          .requiredNavigationEquipage(RequiredNavigationEquipage.RNAV)
+          .build();
+
+      return FluentRouteExpander.inMemoryBuilder(List.of(wsss, other), List.of(sid, star), List.of(), List.of(paspu, lebat)).build();
+    }
+}

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
@@ -66,13 +66,6 @@ import org.mitre.tdp.boogie.alg.split.Wildcard;
 class FluentRouteExpanderTest {
 
   @Test
-  void testSameName() {
-    String route = "PIBAP..PASPU.LEBA2A.WSSS";
-    Fix pibap = fix("PIBAP", 9.0, 9.0);
-
-  }
-
-  @Test
   void testNoWeight() {
     String route = "WSSS.CHA1C.ANITO";
     Fix anito = fix("ANITO", -0.2833, 104.8667);

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
@@ -66,6 +66,13 @@ import org.mitre.tdp.boogie.alg.split.Wildcard;
 class FluentRouteExpanderTest {
 
   @Test
+  void testSameName() {
+    String route = "PIBAP..PASPU.LEBA2A.WSSS";
+    Fix pibap = fix("PIBAP", 9.0, 9.0);
+
+  }
+
+  @Test
   void testNoWeight() {
     String route = "WSSS.CHA1C.ANITO";
     Fix anito = fix("ANITO", -0.2833, 104.8667);


### PR DESCRIPTION
Long story short you can get a situation where tokenA (in plan) and tokenB (inferred) result in a mismatch.
So if e.g., TokenA was a procedure but it had no transitions (e.g., star with no common) and token B was a runway transition of that same star .... the first token will essentially get skipped in favor of any other possible resolved tokens.

