### PR TITLE
fix: forgot to filter for primary records in procedure leg. Which is …

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v19/ProcedureLegSpec.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v19/ProcedureLegSpec.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.mitre.tdp.boogie.arinc.RecordField;
 import org.mitre.tdp.boogie.arinc.RecordSpec;
+import org.mitre.tdp.boogie.arinc.utils.PrimaryRecord;
 import org.mitre.tdp.boogie.arinc.v18.field.*;
 import org.mitre.tdp.boogie.arinc.v19.field.AltitudeDescription;
 import org.mitre.tdp.boogie.arinc.v19.field.RouteTypeQualifier;
@@ -86,7 +87,8 @@ public final class ProcedureLegSpec implements RecordSpec {
   @Override
   public boolean matchesRecord(String arincRecord) {
     String sectionSubsection = arincRecord.substring(4, 5).concat(arincRecord.substring(12, 13));
-    return sectionSubSections.contains(sectionSubsection);
+    return sectionSubSections.contains(sectionSubsection)
+        && PrimaryRecord.INSTANCE.test(arincRecord.substring(38, 39));
   }
 
   private static final HashSet<String> sectionSubSections = newHashSet("PD", "PE", "PF");

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v20/ProcedureLegSpec.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v20/ProcedureLegSpec.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.mitre.tdp.boogie.arinc.RecordField;
 import org.mitre.tdp.boogie.arinc.RecordSpec;
+import org.mitre.tdp.boogie.arinc.utils.PrimaryRecord;
 import org.mitre.tdp.boogie.arinc.v18.field.*;
 import org.mitre.tdp.boogie.arinc.v19.field.RouteTypeQualifier;
 import org.mitre.tdp.boogie.arinc.v20.field.AltitudeDescription;
@@ -89,7 +90,8 @@ public final class ProcedureLegSpec implements RecordSpec {
   @Override
   public boolean matchesRecord(String arincRecord) {
     String sectionSubsection = arincRecord.substring(4, 5).concat(arincRecord.substring(12, 13));
-    return sectionSubSections.contains(sectionSubsection);
+    return sectionSubSections.contains(sectionSubsection)
+        && PrimaryRecord.INSTANCE.test(arincRecord.substring(38, 39));
   }
 
   private static final HashSet<String> sectionSubSections = newHashSet("PD", "PE", "PF");

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v21/ProcedureLegSpec.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v21/ProcedureLegSpec.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.mitre.tdp.boogie.arinc.RecordField;
 import org.mitre.tdp.boogie.arinc.RecordSpec;
+import org.mitre.tdp.boogie.arinc.utils.PrimaryRecord;
 import org.mitre.tdp.boogie.arinc.v18.field.*;
 import org.mitre.tdp.boogie.arinc.v20.field.LegInboundOutboundIndicator;
 import org.mitre.tdp.boogie.arinc.v21.field.AltitudeDescription;
@@ -89,7 +90,8 @@ public class ProcedureLegSpec implements RecordSpec {
   @Override
   public boolean matchesRecord(String arincRecord) {
     String sectionSubsection = arincRecord.substring(4, 5).concat(arincRecord.substring(12, 13));
-    return sectionSubSections.contains(sectionSubsection);
+    return sectionSubSections.contains(sectionSubsection)
+        && PrimaryRecord.INSTANCE.test(arincRecord.substring(38, 39));
   }
 
   private static final Set<String> sectionSubSections = Set.of("PD", "PE", "PF");

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v22/ProcedureLegSpec.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v22/ProcedureLegSpec.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.mitre.tdp.boogie.arinc.RecordField;
 import org.mitre.tdp.boogie.arinc.RecordSpec;
+import org.mitre.tdp.boogie.arinc.utils.PrimaryRecord;
 import org.mitre.tdp.boogie.arinc.v18.field.*;
 import org.mitre.tdp.boogie.arinc.v20.field.LegInboundOutboundIndicator;
 import org.mitre.tdp.boogie.arinc.v21.field.GnssFmsIndicator;
@@ -91,7 +92,8 @@ public class ProcedureLegSpec implements RecordSpec {
   @Override
   public boolean matchesRecord(String arincRecord) {
     String sectionSubsection = arincRecord.substring(4, 5).concat(arincRecord.substring(12, 13));
-    return sectionSubSections.contains(sectionSubsection);
+    return sectionSubSections.contains(sectionSubsection)
+        && PrimaryRecord.INSTANCE.test(arincRecord.substring(38, 39));
   }
 
   private static final Set<String> sectionSubSections = Set.of("PD", "PE", "PF");


### PR DESCRIPTION
…an issue for those using their own coverters later.