### PR TITLE
feat: hashers for all legs and turning back on github packages.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,8 +99,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-#      - name: Publish Jars
-#        run: ./gradlew publish -PghprToken=${{ secrets.GITHUB_TOKEN }} -Pversion=${{steps.version.outputs.nextStrict}}
+      - name: Publish Jars
+        run: ./gradlew publish -PghprToken=${{ secrets.GITHUB_TOKEN }} -Pversion=${{steps.version.outputs.nextStrict}}
 
       - name: Create GitHub Release
         env:

--- a/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/combine/PathTerminatorBasedLegHasher.java
+++ b/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/combine/PathTerminatorBasedLegHasher.java
@@ -1,115 +1,45 @@
 package org.mitre.tdp.boogie.conformance.alg.assign.combine;
 
-import static org.mitre.tdp.boogie.PathTerminator.AF;
-import static org.mitre.tdp.boogie.PathTerminator.CA;
-import static org.mitre.tdp.boogie.PathTerminator.CF;
-import static org.mitre.tdp.boogie.PathTerminator.CI;
-import static org.mitre.tdp.boogie.PathTerminator.DF;
-import static org.mitre.tdp.boogie.PathTerminator.IF;
-import static org.mitre.tdp.boogie.PathTerminator.RF;
-import static org.mitre.tdp.boogie.PathTerminator.TF;
-import static org.mitre.tdp.boogie.PathTerminator.VA;
-import static org.mitre.tdp.boogie.PathTerminator.VI;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.mitre.caasd.commons.Pair;
+import org.apache.commons.math3.util.FastMath;
 import org.mitre.tdp.boogie.Fix;
 import org.mitre.tdp.boogie.Leg;
 import org.mitre.tdp.boogie.PathTerminator;
 import org.mitre.tdp.boogie.conformance.alg.assign.FlyableLeg;
 
-import com.google.common.base.Preconditions;
-
 /**
- * This is an example of a hasher which can be used in situ with a {@link HashCombinationStrategy} to generate hashes for legs
+ * This is a hasher that can be used in situ with a {@link HashCombinationStrategy} to generate hashes for legs
  * based on their expected unique contents (generally determined by their {@link PathTerminator}).
- *
- * If you scan a cycle of data across CIFP/LIDO or some other source combination the most frequent leg types are:
- *
- * ["VR" 105]
- * ["HA" 260]
- * ["VD" 281]
- * ["CR" 619]
- * ["CD" 1495]
- * ["FC" 3880]
- * ["FD" 4005]
- * ["FM" 4140]
- * ["RF" 4874]
- * ["PI" 4915]
- * ["VI" 4941]
- * ["FA" 8500]
- * ["VM" 9557]
- * ["VA" 12532]
- * ["HF" 14508]
- * ["CI" 15133]
- * ["AF" 20196]
- * ["HM" 36691]
- * ["CA" 37787]
- * ["DF" 56860]
- * ["CF" 73486]
- * ["IF" 198425]
- * ["TF" 457939]
- *
- * Generally speaking this class prioritizes hash-based mappings for the most common leg types and defaults the others to
- * using the native leg hashCode.
  */
 public final class PathTerminatorBasedLegHasher implements Function<FlyableLeg, Integer> {
 
-  public final HashMap<PathTerminator, Function<FlyableLeg, Integer>> hashers;
-
-  private PathTerminatorBasedLegHasher(Map<PathTerminator, Function<FlyableLeg, Integer>> overrides) {
-    this.hashers = new HashMap<>();
-    this.initialize();
-    this.hashers.putAll(overrides);
+  private PathTerminatorBasedLegHasher() {
   }
 
   /**
-   * Returns a new instance of a {@link PathTerminatorBasedLegHasher} with the default hashing functions per leg type.
+   * Returns a new instance of a {@link PathTerminatorBasedLegHasher} with the hashing functions per leg type.
    */
   public static PathTerminatorBasedLegHasher newInstance() {
-    return withOverriddenHashers(new HashMap<>());
-  }
-
-  /**
-   * Returns a new instance of a {@link PathTerminatorBasedLegHasher} with the supplied overrides.
-   */
-  public static PathTerminatorBasedLegHasher withOverriddenHashers(Pair<PathTerminator, Function<FlyableLeg, Integer>>... overrides) {
-    return withOverriddenHashers(Stream.of(overrides).collect(Collectors.toMap(Pair::first, Pair::second)));
-  }
-
-  /**
-   * Returns a new instance of a {@link PathTerminatorBasedLegHasher} with the supplied mapping of overrides.
-   */
-  public static PathTerminatorBasedLegHasher withOverriddenHashers(Map<PathTerminator, Function<FlyableLeg, Integer>> overrides) {
-    return new PathTerminatorBasedLegHasher(overrides);
+    return new PathTerminatorBasedLegHasher();
   }
 
   @Override
   public Integer apply(FlyableLeg flyableLeg) {
-    return hashers.getOrDefault(flyableLeg.current().pathTerminator(), Object::hashCode).apply(flyableLeg);
-  }
-
-  private void initialize() {
-    hashers.put(IF, this::ifHasher);
-    hashers.put(TF, this::tfHasher);
-    hashers.put(CF, this::cfHasher);
-    hashers.put(DF, this::dfHasher);
-    // FA, FC, FD, FM
-    hashers.put(CA, this::caHasher);
-    // CD
-    hashers.put(CI, this::ciHasher);
-    hashers.put(RF, this::rfHasher);
-    hashers.put(AF, this::afHasher);
-    hashers.put(VA, this::vaHasher);
-    // VD
-    hashers.put(VI, this::viHasher);
-    // VM, VR, PR, HA, HF, HM
+    return switch (flyableLeg.current().pathTerminator()) {
+      case IF, TF, DF -> xfHash(flyableLeg);
+      case CF -> cfHash(flyableLeg);
+      case FA, FC, FD, FM -> fxHash(flyableLeg);
+      case CA, VA -> xaHash(flyableLeg);
+      case CR, VR -> xrHash(flyableLeg);
+      case CD, VD -> xdHash(flyableLeg);
+      case CI, VI, VM -> xiHash(flyableLeg);
+      case RF -> rfHash(flyableLeg);
+      case AF -> afHash(flyableLeg);
+      case PI -> piHash(flyableLeg);
+      case HA, HF, HM -> hxHash(flyableLeg);
+    };
   }
 
   private static class Hasher {
@@ -127,23 +57,29 @@ public final class PathTerminatorBasedLegHasher implements Function<FlyableLeg, 
       return this;
     }
 
-    public Hasher withPathTerminator(Leg leg) {
+    public Hasher withAssociatedFix(Leg leg) {
       Fix associatedFix = leg.associatedFix().orElseThrow(IllegalStateException::new);
       builder.append(associatedFix.fixIdentifier());
-      builder.append(Math.round(associatedFix.latitude() / HASH_RESOLUTION));
-      builder.append(Math.round(associatedFix.longitude() / HASH_RESOLUTION));
+      builder.append(FastMath.round(associatedFix.latitude() / HASH_RESOLUTION));
+      builder.append(FastMath.round(associatedFix.longitude() / HASH_RESOLUTION));
       return this;
     }
 
     public Hasher withRecommendedNavaid(Leg leg) {
-      builder.append(leg.recommendedNavaid().map(Fix::fixIdentifier).orElse(null));
-      builder.append(leg.recommendedNavaid().map(Fix::latLong).orElse(null));
+      leg.recommendedNavaid().ifPresent(n -> {
+        builder.append(n.fixIdentifier());
+        builder.append(FastMath.round(n.latitude() / HASH_RESOLUTION));
+        builder.append(FastMath.round(n.longitude() / HASH_RESOLUTION));
+      });
       return this;
     }
 
     public Hasher withArcCenter(Leg leg) {
-      builder.append(leg.centerFix().map(Fix::fixIdentifier).orElseThrow(IllegalStateException::new));
-      builder.append(leg.centerFix().map(Fix::latLong).orElseThrow(IllegalStateException::new));
+      leg.centerFix().ifPresent(c -> {
+        builder.append(c.fixIdentifier());
+        builder.append(c.latitude()); //can be quite close so lets not round it
+        builder.append(c.longitude());
+      });
       return this;
     }
 
@@ -156,25 +92,15 @@ public final class PathTerminatorBasedLegHasher implements Function<FlyableLeg, 
     return new Hasher().append(flyableLeg.current().pathTerminator());
   }
 
-  private int ifHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(IF));
-    return newHasher(flyableLeg).withPathTerminator(flyableLeg.current()).buildHash();
-  }
-
-  private int tfHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(TF));
-    Hasher hasher = newHasher(flyableLeg).withPathTerminator(flyableLeg.current());
-    return flyableLeg.previous().filter(l -> l.associatedFix().isPresent()).isPresent()
-        // allow null previous fixes because the scorer lets them pass as well I think
-        // this is likely an issue with CIFP airways on the boundary of countries
-        ? hasher.withPathTerminator(flyableLeg.previous().orElseThrow(IllegalStateException::new)).buildHash()
-        : hasher.buildHash();
-  }
-
-  private int cfHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(CF));
+  private int xfHash(FlyableLeg flyableLeg) {
     return newHasher(flyableLeg)
-        .withPathTerminator(flyableLeg.current())
+        .withAssociatedFix(flyableLeg.current())
+        .buildHash();
+  }
+
+  private int cfHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg)
+        .withAssociatedFix(flyableLeg.current())
         .withRecommendedNavaid(flyableLeg.current())
         .append(flyableLeg.current().theta().orElse(null))
         .append(flyableLeg.current().rho().orElse(null))
@@ -183,35 +109,25 @@ public final class PathTerminatorBasedLegHasher implements Function<FlyableLeg, 
         .buildHash();
   }
 
-  private int dfHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(DF));
-    return newHasher(flyableLeg).withPathTerminator(flyableLeg.current()).buildHash();
-  }
-
-  private int caHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(CA));
-    return newHasher(flyableLeg).append(flyableLeg.current().outboundMagneticCourse().orElse(null)).buildHash();
-  }
-
-  private int ciHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(CI));
-    return newHasher(flyableLeg).append(flyableLeg.current().outboundMagneticCourse().orElse(null)).buildHash();
-  }
-
-  private int rfHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(RF));
+  private int xaHash(FlyableLeg flyableLeg) {
     return newHasher(flyableLeg)
-        .withPathTerminator(flyableLeg.current())
+        .append(flyableLeg.current().outboundMagneticCourse().orElse(null))
+        .append(flyableLeg.current().altitudeConstraint().lowerEndpoint())
+        .buildHash();
+  }
+
+  private int rfHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg)
+        .withAssociatedFix(flyableLeg.current())
         .withArcCenter(flyableLeg.current())
-        .withPathTerminator(flyableLeg.previous().orElseThrow(IllegalStateException::new))
+        .withAssociatedFix(flyableLeg.previous().orElseThrow(IllegalStateException::new))
         .append(flyableLeg.current().turnDirection().orElseThrow(IllegalStateException::new))
         .buildHash();
   }
 
-  private int afHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(AF));
+  private int afHash(FlyableLeg flyableLeg) {
     return newHasher(flyableLeg)
-        .withPathTerminator(flyableLeg.current())
+        .withAssociatedFix(flyableLeg.current())
         .withRecommendedNavaid(flyableLeg.current())
         .append(flyableLeg.current().turnDirection())
         .append(flyableLeg.current().theta().orElse(null))
@@ -219,16 +135,54 @@ public final class PathTerminatorBasedLegHasher implements Function<FlyableLeg, 
         .buildHash();
   }
 
-  private int vaHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(VA));
+  private int xiHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg).append(flyableLeg.current().outboundMagneticCourse().orElse(null)).buildHash();
+  }
+
+  private int fxHash(FlyableLeg flyableLeg) {
     return newHasher(flyableLeg)
+        .withAssociatedFix(flyableLeg.current())
+        .withRecommendedNavaid(flyableLeg.current())
+        .append(flyableLeg.current().theta().orElse(null))
+        .append(flyableLeg.current().rho().orElse(null))
         .append(flyableLeg.current().outboundMagneticCourse().orElse(null))
-        .append(flyableLeg.current().altitudeConstraint().lowerEndpoint())
         .buildHash();
   }
 
-  private int viHasher(FlyableLeg flyableLeg) {
-    Preconditions.checkArgument(flyableLeg.current().pathTerminator().equals(VI));
-    return newHasher(flyableLeg).append(flyableLeg.current().outboundMagneticCourse().orElse(null)).buildHash();
+  private int xrHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg)
+        .withRecommendedNavaid(flyableLeg.current())
+        .append(flyableLeg.current().theta().orElse(null))
+        .append(flyableLeg.current().outboundMagneticCourse().orElse(null))
+        .buildHash();
+  }
+
+  private int xdHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg)
+        .withRecommendedNavaid(flyableLeg.current())
+        .append(flyableLeg.current().routeDistance().orElse(null))
+        .append(flyableLeg.current().outboundMagneticCourse().orElse(null))
+        .buildHash();
+  }
+
+  private int piHash(FlyableLeg flyableLeg) {
+    return newHasher(flyableLeg)
+        .withAssociatedFix(flyableLeg.current())
+        .withRecommendedNavaid(flyableLeg.current())
+        .append(flyableLeg.current().theta().orElse(null))
+        .append(flyableLeg.current().rho().orElse(null))
+        .append(flyableLeg.current().outboundMagneticCourse().orElse(null))
+        .append(flyableLeg.current().turnDirection().orElse(null))
+        .append(flyableLeg.current().routeDistance().orElse(null))
+        .buildHash();
+  }
+
+  private int hxHash(FlyableLeg flyableLeg) {
+    Hasher hasher = newHasher(flyableLeg)
+        .withAssociatedFix(flyableLeg.current())
+        .append(flyableLeg.current().turnDirection().orElse(null));
+    flyableLeg.current().holdTime().ifPresent(hasher::append);
+    flyableLeg.current().routeDistance().ifPresent(hasher::append);
+    return hasher.buildHash();
   }
 }

--- a/boogie-conformance/src/test/java/org/mitre/tdp/boogie/conformance/alg/assign/TestRouteExtraction.java
+++ b/boogie-conformance/src/test/java/org/mitre/tdp/boogie/conformance/alg/assign/TestRouteExtraction.java
@@ -1,0 +1,4 @@
+package org.mitre.tdp.boogie.conformance.alg.assign;
+
+public class TestRouteExtraction {
+}

--- a/boogie-conformance/src/test/java/org/mitre/tdp/boogie/conformance/alg/assign/combine/TestPathTerminatorBasedLegHasher.java
+++ b/boogie-conformance/src/test/java/org/mitre/tdp/boogie/conformance/alg/assign/combine/TestPathTerminatorBasedLegHasher.java
@@ -27,8 +27,8 @@ class TestPathTerminatorBasedLegHasher {
     Integer hash1 = hasher.apply(flyableLeg1);
 
     // from 4oPjcWRT84AAchP, RW21R at KPSC
-    LatLong jeppLatLong = LatLong.of(46.268417341819735, -119.11506482388177);
-    FlyableLeg flyableLeg2 = mockFlyableLeg(PathTerminator.TF, jeppLatLong);
+    LatLong latLongJ = LatLong.of(46.268417341819735, -119.11506482388177);
+    FlyableLeg flyableLeg2 = mockFlyableLeg(PathTerminator.TF, latLongJ);
     Integer hash2 = hasher.apply(flyableLeg2);
 
     assertEquals(hash1, hash2, "Legs with similar path terminating fixes should hash together");

--- a/boogie-core/src/main/java/org/mitre/tdp/boogie/validate/PathTerminatorBasedLegValidator.java
+++ b/boogie-core/src/main/java/org/mitre/tdp/boogie/validate/PathTerminatorBasedLegValidator.java
@@ -67,8 +67,6 @@ public final class PathTerminatorBasedLegValidator implements Predicate<Leg> {
           && leg.outboundMagneticCourse().isPresent()
           // only one or the other must be present on the record
           && (leg.holdTime().isPresent() || leg.routeDistance().isPresent());
-      default ->
-          throw new IllegalArgumentException("Unsupported leg type supplied to LegContentValidator: ".concat(leg.pathTerminator().name()));
     };
   }
 }


### PR DESCRIPTION
This adds the missing hashers for the flyable legs. Honestly it must has taken more time to get the numbers on what was used when, then to just make them all. 