### PR TITLE
Adding Tokenizer for TFM restrictions.

### DIFF
--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/RouteTokenResolver.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/RouteTokenResolver.java
@@ -8,16 +8,13 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-import org.mitre.caasd.commons.LatLong;
 import org.mitre.tdp.boogie.Airport;
 import org.mitre.tdp.boogie.Airway;
 import org.mitre.tdp.boogie.Fix;
-import org.mitre.tdp.boogie.Leg;
 import org.mitre.tdp.boogie.Procedure;
 import org.mitre.tdp.boogie.Transition;
 import org.mitre.tdp.boogie.alg.LookupService;
@@ -63,7 +60,7 @@ public interface RouteTokenResolver {
         .addResolver(airway(airwaysByName))
         .addResolver(fix(fixesByName))
         .addResolver(frd(fixesByName))
-        .addResolver(latlong(null))
+        .addResolver(latlong())
         .build();
   }
 
@@ -155,7 +152,7 @@ public interface RouteTokenResolver {
    *
    * <p>Supports both ICAO and FAA coordinate standards out-of-the-box.
    */
-  static RouteTokenResolver latlong(Function<LatLong, Leg> toLeg) {
+  static RouteTokenResolver latlong() {
     return new LatLongResolver();
   }
 

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/split/RouteTokenizer.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/split/RouteTokenizer.java
@@ -42,6 +42,15 @@ public interface RouteTokenizer {
   }
 
   /**
+   * Route tokenizer for TfmRestriction strings
+   * <p> e.g., {@code DRSDN/AFM or J121}
+   * @return The tfm restriction tokenizer
+   */
+  static RouteTokenizer tfmRestrictionFormat() {
+    return new TfmRestrictionTokenizer();
+  }
+
+  /**
    * Tokenize an input route of some (potentially undetermined format) and convert it to token identifiers which can be matched
    * against infrastructure using various {@link RouteTokenResolver} implementations.
    *

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/split/TfmRestrictionTokenizer.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/split/TfmRestrictionTokenizer.java
@@ -1,0 +1,27 @@
+package org.mitre.tdp.boogie.alg.split;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+/**
+ * This is meant to tokenize TFM restrictions into a list of {@link RouteToken}s.
+ * TFM restrictions come with airports and then the restriction elements that are meant to be resolved here.
+ */
+public final class TfmRestrictionTokenizer implements RouteTokenizer {
+  TfmRestrictionTokenizer() {}
+  @Override
+  public List<RouteToken> tokenize(String route) {
+    String[] splits = route.split("/");
+    return IntStream.range(0, splits.length)
+        .mapToObj(i -> {
+          String tkn = splits[i].trim();
+          if (tkn.isBlank()) {
+            return null;
+          }
+          return RouteToken.standard(tkn, i);
+        })
+        .filter(Objects::nonNull)
+        .toList();
+  }
+}

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphExporterTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphExporterTest.java
@@ -24,7 +24,7 @@ class GraphExporterTest {
 
   private String createLatLongId(String latLong) {
 
-    ResolvedToken token = RouteTokenResolver.latlong(null)
+    ResolvedToken token = RouteTokenResolver.latlong()
         .resolve(null, RouteToken.standard(latLong, 0), null)
         .resolvedTokens()
         .iterator()

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/split/TfmRestrictionTokenizerTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/split/TfmRestrictionTokenizerTest.java
@@ -1,0 +1,87 @@
+package org.mitre.tdp.boogie.alg.split;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class TfmRestrictionTokenizerTest {
+
+  private static final RouteTokenizer TOKENIZER = RouteTokenizer.tfmRestrictionFormat();
+
+  @Test
+  void testSingleToken() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("DRSDN");
+
+    assertEquals(1, tokens.size());
+    assertAll(
+        () -> assertEquals("DRSDN", tokens.get(0).infrastructureName()),
+        () -> assertEquals(0.0, tokens.get(0).index())
+    );
+  }
+
+  @Test
+  void testTwoTokens() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("DRSDN/AFM");
+
+    assertEquals(2, tokens.size());
+    assertAll(
+        () -> assertEquals("DRSDN", tokens.get(0).infrastructureName()),
+        () -> assertEquals(0.0, tokens.get(0).index()),
+        () -> assertEquals("AFM", tokens.get(1).infrastructureName()),
+        () -> assertEquals(1.0, tokens.get(1).index())
+    );
+  }
+
+  @Test
+  void testMultipleTokens() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("KATL/CHPPR1/DRSDN/J121/JMACK/HOBTT");
+
+    assertEquals(6, tokens.size());
+    assertAll(
+        () -> assertEquals("KATL", tokens.get(0).infrastructureName()),
+        () -> assertEquals(0.0, tokens.get(0).index()),
+        () -> assertEquals("CHPPR1", tokens.get(1).infrastructureName()),
+        () -> assertEquals(1.0, tokens.get(1).index()),
+        () -> assertEquals("DRSDN", tokens.get(2).infrastructureName()),
+        () -> assertEquals(2.0, tokens.get(2).index()),
+        () -> assertEquals("J121", tokens.get(3).infrastructureName()),
+        () -> assertEquals(3.0, tokens.get(3).index()),
+        () -> assertEquals("JMACK", tokens.get(4).infrastructureName()),
+        () -> assertEquals(4.0, tokens.get(4).index()),
+        () -> assertEquals("HOBTT", tokens.get(5).infrastructureName()),
+        () -> assertEquals(5.0, tokens.get(5).index())
+    );
+  }
+
+  @Test
+  void testEmptyString() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("");
+
+    assertEquals(0, tokens.size());
+  }
+
+  @Test
+  void testTrailingSlash() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("DRSDN/");
+
+    assertEquals(1, tokens.size());
+    assertAll(
+        () -> assertEquals("DRSDN", tokens.get(0).infrastructureName()),
+        () -> assertEquals(0.0, tokens.get(0).index())
+    );
+  }
+
+  @Test
+  void testLeadingSlash() {
+    List<RouteToken> tokens = TOKENIZER.tokenize("/DRSDN");
+
+    assertEquals(1, tokens.size());
+    assertAll(
+        () -> assertEquals("DRSDN", tokens.get(0).infrastructureName()),
+        () -> assertEquals(1.0, tokens.get(0).index(), "Its ok as long as its the lowest number in the list.")
+    );
+  }
+}


### PR DESCRIPTION
Simple enough, but getting it into boogie lets us use section resolvers next.