### PR TITLE
feat: new inferences for airways.

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ArincAirwayLeg.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ArincAirwayLeg.java
@@ -48,7 +48,6 @@ import org.mitre.tdp.boogie.arinc.v22.field.qualifiers.AirwayQualifier3;
  * class then mimics a single line of an ARINC airway record. These legs can then be sequenced to produce a full airway definition.
  */
 public final class ArincAirwayLeg implements ArincModel {
-
   /**
    * See {@link RecordType}.
    */
@@ -252,6 +251,10 @@ public final class ArincAirwayLeg implements ArincModel {
     this.routeTypeQualifier3 = builder.routeTypeQualifier3;
     this.fileRecordNumber = builder.fileRecordNumber;
     this.lastUpdateCycle = builder.lastUpdateCycle;
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   public RecordType recordType() {

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v18/AirwayLegBuilder.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/v18/AirwayLegBuilder.java
@@ -1,10 +1,7 @@
 package org.mitre.tdp.boogie.arinc.v18;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.mitre.tdp.boogie.arinc.ArincRecord;
 import org.mitre.tdp.boogie.arinc.model.ArincAirwayLeg;
@@ -42,7 +39,7 @@ public final class AirwayLegBuilder implements Function<ArincRecord, ArincAirway
 
     RouteHoldDistanceTime routeHoldDistanceTimeConverter = new RouteHoldDistanceTime();
 
-    return new ArincAirwayLeg.Builder()
+    return ArincAirwayLeg.builder()
         .recordType(arincRecord.requiredField("recordType"))
         .customerAreaCode(arincRecord.requiredField("customerAreaCode"))
         .sectionCode(arincRecord.requiredField("sectionCode"))

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/assemble/TestLidoAirwayAssemblerIntegration.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/assemble/TestLidoAirwayAssemblerIntegration.java
@@ -1,0 +1,75 @@
+package org.mitre.tdp.boogie.arinc.assemble;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mitre.caasd.commons.Pair;
+import org.mitre.tdp.boogie.Airway;
+import org.mitre.tdp.boogie.Leg;
+import org.mitre.tdp.boogie.arinc.EmbeddedLidoFile;
+import org.mitre.tdp.boogie.arinc.database.ArincDatabaseFactory;
+import org.mitre.tdp.boogie.arinc.database.ArincFixDatabase;
+import org.mitre.tdp.boogie.validate.PathTerminatorBasedLegValidator;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+@Tag("LIDO")
+@Tag("INTEGRATION")
+public class TestLidoAirwayAssemblerIntegration {
+
+  private static Multimap<String, Airway> airwaysByName;
+
+  @BeforeAll
+  static void setup() {
+    ArincFixDatabase arincFixDatabase = ArincDatabaseFactory.newFixDatabase(
+        EmbeddedLidoFile.instance().arincNdbNavaids(),
+        EmbeddedLidoFile.instance().arincVhfNavaids(),
+        EmbeddedLidoFile.instance().arincWaypoints(),
+        EmbeddedLidoFile.instance().arincAirports(),
+        EmbeddedLidoFile.instance().arincHoldingPatterns(),
+        EmbeddedLidoFile.instance().arincHeliports()
+    );
+
+    AirwayAssembler<Airway> assembler = AirwayAssembler.standard(arincFixDatabase);
+
+    airwaysByName = assembler.assemble(EmbeddedLidoFile.instance().arincAirwayLegs()).collect(ArrayListMultimap::create, (m, i) -> m.put(i.airwayIdentifier(), i), Multimap::putAll);
+  }
+
+  @Test
+  void testGlobalAirwayCountIsAccurate() {
+    assertEquals(14588, airwaysByName.values().size());
+  }
+
+  @Test
+  void testMaxAssembledSegmentsPerAirwayIdentifier() {
+    int maxSegmentsPerIdentifier = airwaysByName.asMap().values().stream()
+        .mapToInt(Collection::size)
+        .max()
+        .orElse(0);
+
+    assertEquals(12, maxSegmentsPerIdentifier, "Observed in A424-22std.dat.gz for V16");
+  }
+
+  @Test
+  void testRatioOfInvalidLegsInAssembledAirways() {
+    Predicate<Leg> validLeg = new PathTerminatorBasedLegValidator();
+
+    Multimap<Leg, Airway> allLegs = airwaysByName.values().stream()
+        .flatMap(airway -> airway.legs().stream().map(leg -> Pair.of(leg, airway)))
+        .collect(ArrayListMultimap::create, (m, i) -> m.put(i.first(), i.second()), Multimap::putAll);
+
+    Multimap<Leg, Airway> invalidLegs = allLegs.entries().stream()
+        .filter(entry -> validLeg.negate().test(entry.getKey()))
+        .collect(ArrayListMultimap::create, (m, i) -> m.put(i.getKey(), i.getValue()), Multimap::putAll);
+
+    double invalidRatio = (double) invalidLegs.size() / (double) allLegs.size();
+
+    assertEquals(0., invalidRatio, .001, "Expected less than .1% of airway legs to be invalid.");
+  }
+}

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/RouteContext.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/RouteContext.java
@@ -186,6 +186,15 @@ public interface RouteContext {
     }
 
     /**
+     * Infers end-to-end airway segment continuations for multiply-resolved airway route tokens.
+     *
+     * @return the continuous airway inferrer
+     */
+    private SectionInferrer continuousAirway() {
+      return SectionInferrer.continuousAirway();
+    }
+
+    /**
      * A section inferrer for the departing airport
      * @return the inferrer for the default star
      */
@@ -241,7 +250,7 @@ public interface RouteContext {
       return new RouteContext() {
         @Override
         public List<SectionInferrer> inferrers() {
-          return List.of(defaultSid(), defaultStar(), sidRunwayTransition(), starRunwayTransition(), approach());
+          return List.of(continuousAirway(), defaultSid(), defaultStar(), sidRunwayTransition(), starRunwayTransition(), approach());
         }
 
         @Override

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/infer/ContinuousAirwayInferrer.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/infer/ContinuousAirwayInferrer.java
@@ -1,0 +1,234 @@
+package org.mitre.tdp.boogie.alg.resolve.infer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.mitre.tdp.boogie.Airway;
+import org.mitre.tdp.boogie.Fix;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedToken;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedTokenVisitor;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedTokens;
+import org.mitre.tdp.boogie.alg.split.RouteToken;
+
+/**
+ * Infers additional airway segments between a multiply-resolved airway section and a downstream fix.
+ * <p>
+ * A single airway identifier in a route string (e.g. {@code FIX.W1.FIX}) may resolve to several {@link Airway} segments with
+ * the same name. Source data can split one logical route into multiple records (sequence-number jumps, boundary codes, etc.). When
+ * those segments connect end to end — the last fix of one equals the first fix of the next — they may represent one continuous
+ * path to the filed exit fix.
+ * <p>
+ * In practice a single airway identifier resolves to a small number of segments. In {@code A424-22std.dat.gz} the maximum is
+ * twelve assembled segments sharing one identifier ({@code V16}); most identifiers produce one or two. The search is tuned for
+ * that scale rather than large graphs.
+ *
+ * @see SectionInferrer
+ * @see ResolvedToken#standardAirway(Airway)
+ */
+final class ContinuousAirwayInferrer implements SectionInferrer {
+
+  ContinuousAirwayInferrer(){}
+
+  /**
+   * Returns the fix identifier filed in the right section, if present.
+   */
+  private static Optional<String> rightFixIdent(ResolvedTokens right) {
+    return right.resolvedTokens().stream()
+        .flatMap(t -> ResolvedTokenVisitor.fix(t).stream())
+        .findFirst()
+        .map(Fix::fixIdentifier);
+  }
+
+  /**
+   * Collects all airway candidates resolved for the left section.
+   */
+  private static List<Airway> leftAirways(ResolvedTokens left) {
+    return left.resolvedTokens().stream()
+        .flatMap(t -> ResolvedTokenVisitor.airway(t).stream())
+        .toList();
+  }
+
+  /**
+   * Converts each continuation layer into a {@link ResolvedTokens} section sharing the original route token.
+   */
+  private static List<ResolvedTokens> inferContinuations(RouteToken routeToken, List<Airway> airways, String targetFixIdent) {
+    return AirwayGraph.of(airways)
+        .continuationLayers(targetFixIdent)
+        .stream()
+        .map(continuations -> new ResolvedTokens(
+            routeToken,
+            continuations.stream().<ResolvedToken>map(ResolvedToken::standardAirway).toList()))
+        .toList();
+  }
+
+  @Override
+  public List<ResolvedTokens> inferBetween(ResolvedTokens left, ResolvedTokens right) {
+    return Optional.of(left)
+        .filter(section -> section.resolvedTokens().size() > 1)
+        .flatMap(section -> rightFixIdent(right)
+            .map(target -> inferContinuations(section.routeToken(), leftAirways(section), target)))
+        .orElseGet(List::of);
+  }
+
+  /**
+   * First and last fix identifiers for an airway segment.
+   */
+  private record AirwayEndpoints(String firstFix, String lastFix) {
+    private static AirwayEndpoints of(Airway airway) {
+      return new AirwayEndpoints(
+          airway.legs().get(0).associatedFix().orElseThrow().fixIdentifier(),
+          airway.legs().get(airway.legs().size() - 1).associatedFix().orElseThrow().fixIdentifier());
+    }
+  }
+
+  /**
+   * An airway segment with a stable index into the left-section candidate list.
+   */
+  private record IndexedAirway(int index, Airway airway, AirwayEndpoints endpoints) {
+    private static IndexedAirway of(int index, Airway airway) {
+      return new IndexedAirway(index, airway, AirwayEndpoints.of(airway));
+    }
+
+    private String firstFix() {
+      return endpoints.firstFix();
+    }
+
+    private String lastFix() {
+      return endpoints.lastFix();
+    }
+  }
+
+  /**
+   * Directed graph of airway segments linked by matching fix identifiers.
+   *
+   * <p>An edge exists from segment {@code A} to segment {@code B} when {@code A}'s last fix equals {@code B}'s first fix.
+   * {@link #successorsByFirstFix} is indexed by first fix so successors of a segment are found via its last fix.
+   */
+  private record AirwayGraph(List<IndexedAirway> indexed, Map<String, List<Integer>> successorsByFirstFix) {
+
+    private static AirwayGraph of(List<Airway> airways) {
+      if (airways.isEmpty()) {
+        return new AirwayGraph(List.of(), Map.of());
+      }
+
+      List<IndexedAirway> indexed = IntStream.range(0, airways.size())
+          .mapToObj(i -> IndexedAirway.of(i, airways.get(i)))
+          .toList();
+
+      Map<String, List<Integer>> successorsByFirstFix = indexed.stream()
+          .collect(Collectors.groupingBy(
+              IndexedAirway::firstFix,
+              Collectors.mapping(IndexedAirway::index, Collectors.toList())));
+
+      return new AirwayGraph(indexed, successorsByFirstFix);
+    }
+
+    /**
+     * Returns ordered layers of continuation segments that can appear between the left airway section and the target fix.
+     *
+     * <p>Layer {@code 0} holds first-hop continuations, layer {@code 1} holds second-hop continuations, and so on. Each layer may
+     * contain multiple {@link Airway} alternatives when several valid chains share or diverge at that hop.
+     */
+    private List<Set<Airway>> continuationLayers(String targetFixIdent) {
+      if (indexed.isEmpty()) {
+        return List.of();
+      }
+
+      List<Airway> airways = indexed.stream().map(IndexedAirway::airway).toList();
+      return SearchContext.begin(airways)
+          .exploreAllFrom(this, startingIndices(targetFixIdent), targetFixIdent)
+          .toLayers();
+    }
+
+    /**
+     * Indices of segments that can begin a path (those not already ending at the target fix).
+     */
+    private IntStream startingIndices(String targetFixIdent) {
+      return indexed.stream()
+          .mapToInt(IndexedAirway::index)
+          .filter(start -> !endsAt(start, targetFixIdent));
+    }
+
+    private boolean endsAt(int index, String targetFixIdent) {
+      return indexed.get(index).lastFix().equals(targetFixIdent);
+    }
+
+    /**
+     * Indices of segments whose first fix matches the last fix of the segment at {@code index}.
+     */
+    private List<Integer> successorsOf(int index) {
+      return successorsByFirstFix.getOrDefault(indexed.get(index).lastFix(), List.of());
+    }
+  }
+
+  /**
+   * Mutable scratch-space for backtracking search over {@link AirwayGraph}.
+   *
+   * <p>{@link #pathLength} advances immutably on {@link #enter} and {@link #leave}; {@link #onPath} and {@link #path} are reused
+   * to avoid allocating on every recursive step. Completed paths are folded into {@link #layers} when a segment ending at the
+   * target fix is reached.
+   */
+  private record SearchContext(List<Airway> airways, boolean[] onPath, int[] path, int pathLength, List<LinkedHashSet<Airway>> layers) {
+
+    private static SearchContext begin(List<Airway> airways) {
+      return new SearchContext(airways, new boolean[airways.size()], new int[airways.size()], 0, new ArrayList<>());
+    }
+
+    /**
+     * Explores from each candidate start index and accumulates all valid continuation layers.
+     */
+    private SearchContext exploreAllFrom(AirwayGraph graph, IntStream starts, String targetFixIdent) {
+      return starts.boxed()
+          .reduce(this, (context, start) -> context.enter(start).exploreFrom(graph, start, targetFixIdent).leave(start), (left, right) -> right);
+    }
+
+    /**
+     * Depth-first search for paths from {@code current} to the target fix, avoiding cycles via {@link #onPath}.
+     */
+    private SearchContext exploreFrom(AirwayGraph graph, int current, String targetFixIdent) {
+      if (graph.endsAt(current, targetFixIdent)) {
+        return absorbCurrentPath();
+      }
+
+      return graph.successorsOf(current).stream()
+          .filter(next -> !onPath[next])
+          .reduce(this, (context, next) -> context.enter(next).exploreFrom(graph, next, targetFixIdent).leave(next), (left, right) -> right);
+    }
+
+    private SearchContext enter(int index) {
+      onPath[index] = true;
+      path[pathLength] = index;
+      return new SearchContext(airways, onPath, path, pathLength + 1, layers);
+    }
+
+    private SearchContext leave(int index) {
+      onPath[index] = false;
+      return new SearchContext(airways, onPath, path, pathLength - 1, layers);
+    }
+
+    /**
+     * Adds all segments after the path start into the appropriate continuation layers.
+     */
+    private SearchContext absorbCurrentPath() {
+      IntStream.range(1, pathLength).forEach(index -> addToLayer(index - 1, airways.get(path[index])));
+      return this;
+    }
+
+    private void addToLayer(int layer, Airway airway) {
+      while (layers.size() <= layer) {
+        layers.add(new LinkedHashSet<>());
+      }
+      layers.get(layer).add(airway);
+    }
+
+    private List<Set<Airway>> toLayers() {
+      return List.copyOf(layers);
+    }
+  }
+}

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/infer/SectionInferrer.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/resolve/infer/SectionInferrer.java
@@ -115,6 +115,16 @@ public interface SectionInferrer {
   }
 
   /**
+   * Infers ordered airway-segment continuations when a route token resolves to multiple {@link org.mitre.tdp.boogie.Airway}
+   * candidates that connect end to end toward a downstream filed fix.
+   *
+   * @see ContinuousAirwayInferrer
+   */
+  static SectionInferrer continuousAirway() {
+    return new ContinuousAirwayInferrer();
+  }
+
+  /**
    * Generates a new <i>ordered</i> list of {@link ResolvedTokens}s based on the preceding and following provided sections.
    *
    * @param left  the preceding {@link ResolvedTokens} and its associated elements

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/resolve/infer/ContinuousAirwayInferrerTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/resolve/infer/ContinuousAirwayInferrerTest.java
@@ -1,0 +1,118 @@
+package org.mitre.tdp.boogie.alg.resolve.infer;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.mitre.caasd.commons.LatLong;
+import org.mitre.tdp.boogie.Airway;
+import org.mitre.tdp.boogie.Fix;
+import org.mitre.tdp.boogie.Leg;
+import org.mitre.tdp.boogie.alg.RouteContext;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedToken;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedTokens;
+import org.mitre.tdp.boogie.alg.split.RouteToken;
+
+class ContinuousAirwayInferrerTest {
+
+  /**
+   * Exercises a multi-hop chain below the twelve-segment maximum observed for one identifier in {@code A424-22std.dat.gz}.
+   */
+  @Test
+  void infersOrderedContinuationsForSixSegmentChain() {
+    List<Airway> chain = linkedChain();
+    ResolvedTokens left = multiplyResolvedAirwaySection(chain);
+    ResolvedTokens right = exitFixSection();
+
+    List<ResolvedTokens> inferred = new ContinuousAirwayInferrer().inferBetween(left, right);
+
+    assertAll(
+        () -> assertEquals(chain.size() - 1, inferred.size(), "Should infer one section per hop after the start segment"),
+        () -> IntStream.range(0, chain.size() - 1)
+            .forEach(layer -> assertEquals(
+                expectedLayer(chain, layer),
+                airwaysIn(inferred.get(layer)),
+                "Layer " + layer))
+    );
+  }
+
+  @Test
+  void sectionInferrerFactoryDelegatesToContinuousAirwayInferrer() {
+    ResolvedTokens left = multiplyResolvedAirwaySection(linkedChain());
+    ResolvedTokens right = exitFixSection();
+
+    assertSameInference(left, right, SectionInferrer.continuousAirway());
+  }
+
+  @Test
+  void standardRouteContextRegistersContinuousAirwayInferrerFirst() {
+    ResolvedTokens left = multiplyResolvedAirwaySection(linkedChain());
+    ResolvedTokens right = exitFixSection();
+
+    assertSameInference(left, right, RouteContext.standard().build().inferrers().get(0));
+  }
+
+  private static void assertSameInference(ResolvedTokens left, ResolvedTokens right, SectionInferrer inferrer) {
+    List<ResolvedTokens> expected = new ContinuousAirwayInferrer().inferBetween(left, right);
+    List<ResolvedTokens> actual = inferrer.inferBetween(left, right);
+
+    assertEquals(expected.size(), actual.size());
+    IntStream.range(0, expected.size())
+        .forEach(layer -> assertEquals(airwaysIn(expected.get(layer)), airwaysIn(actual.get(layer)), "Layer " + layer));
+  }
+
+  private static ResolvedTokens multiplyResolvedAirwaySection(List<Airway> chain) {
+    return new ResolvedTokens(
+        RouteToken.standard("W1", 1.),
+        chain.stream().<ResolvedToken>map(ResolvedToken::standardAirway).toList()
+    );
+  }
+
+  private static ResolvedTokens exitFixSection() {
+    return new ResolvedTokens(
+        RouteToken.standard("FIX7", 2.),
+        List.of(ResolvedToken.standardFix(fix("FIX7", 6.0)))
+    );
+  }
+
+  private static List<Airway> linkedChain() {
+    return IntStream.range(0, 6)
+        .mapToObj(i -> segment(
+            "FIX" + (i + 1), i,
+            "FIX" + (i + 2), i + 1))
+        .toList();
+  }
+
+  private static Set<Airway> expectedLayer(List<Airway> chain, int layer) {
+    return new LinkedHashSet<>(chain.subList(layer + 1, chain.size()));
+  }
+
+  private static Fix fix(String identifier, double latitude) {
+    return Fix.builder()
+        .fixIdentifier(identifier)
+        .latLong(LatLong.of(latitude, 0.))
+        .build();
+  }
+
+  private static Airway segment(String from, double fromLatitude, String to, double toLatitude) {
+    Leg entry = Leg.tfBuilder(fix(from, fromLatitude), 1).build();
+    Leg exit = Leg.tfBuilder(fix(to, toLatitude), 2).build();
+    return Airway.builder()
+        .airwayIdentifier("W1")
+        .legs(List.of(entry, exit))
+        .build();
+  }
+
+  private static Set<Airway> airwaysIn(ResolvedTokens tokens) {
+    return tokens.resolvedTokens().stream()
+        .map(ResolvedToken.StandardAirway.class::cast)
+        .map(ResolvedToken.StandardAirway::infrastructure)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+}


### PR DESCRIPTION
Route string of Airway->Fix

except in the source data the Airway resolves to 3 possible airways. Can be different, can be the same, can be split across arinc 424 boundaries with/with-out being linked up with attribution.

So we can't trust the arinc codes to link us up. 

So I'm treating this a bit like figuring our runway transitions based on context.  

I optimized this for small numbers (with the max airway per ident being 12). Since its gets run lots .... we want it efficient.