### PR TITLE
Continuous Airways

### DIFF
--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooser.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooser.java
@@ -7,7 +7,16 @@ import static org.mitre.tdp.boogie.util.Combinatorics.cartesianProduct;
 import static org.mitre.tdp.boogie.util.Iterators.openClose2;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -20,7 +29,11 @@ import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 import org.mitre.caasd.commons.Pair;
-import org.mitre.tdp.boogie.*;
+import org.mitre.tdp.boogie.Fix;
+import org.mitre.tdp.boogie.Leg;
+import org.mitre.tdp.boogie.PathTerminator;
+import org.mitre.tdp.boogie.Procedure;
+import org.mitre.tdp.boogie.TurnDirection;
 import org.mitre.tdp.boogie.alg.ResolvedLeg;
 import org.mitre.tdp.boogie.alg.chooser.graph.LinkableToken;
 import org.mitre.tdp.boogie.alg.chooser.graph.LinkedLegs;
@@ -93,11 +106,15 @@ final class GraphicalRouteChooser implements RouteChooser {
     linkableTokens.stream().flatMap(tokens -> tokens.graphRepresentation().stream())
         .forEach(linkedLegs -> addLinkedLegTo(graph, linkedLegs));
 
+    linkableTokens.stream()
+        .filter(LinkableTokens::supportsIntraLinks)
+        .forEach(tokens -> tokens.intraLinks().forEach(linkedLegs -> addLinkedLegTo(graph, linkedLegs)));
+
     openClose2(
         linkableTokens,
         LinkableTokens::nonEmpty,
         (l, h) -> h.nonEmpty(),
-        (previous, next, skip) -> previous.links(next).forEach(linkedLegs -> addLinkedLegTo(graph, linkedLegs))
+        (previous, next, skip) -> previous.interLinks(next).forEach(linkedLegs -> addLinkedLegTo(graph, linkedLegs))
     );
 
     return graph;
@@ -295,6 +312,10 @@ final class GraphicalRouteChooser implements RouteChooser {
       return !linkableLegs.isEmpty();
     }
 
+    boolean supportsIntraLinks() {
+      return tokens.stream().anyMatch(LinkableToken::supportsIntraLinks);
+    }
+
     /**
      * Some linkers will create new legs (e.g. Any->Approach), it's hard in here to decide what RouteToken/ResolvedToken should
      * be their parent, so we defer this until later on.
@@ -312,7 +333,31 @@ final class GraphicalRouteChooser implements RouteChooser {
           .collect(toList());
     }
 
-    Collection<LinkedLegs> links(LinkableTokens linkableTokens) {
+    /**
+     * Links co-resolved tokens within this section when both token types explicitly support intra-section linking.
+     */
+    Collection<LinkedLegs> intraLinks() {
+      return linkableTokens().stream()
+          .filter(LinkableToken::supportsIntraLinks)
+          .flatMap(source -> linkableTokens().stream()
+              .filter(target -> target != source)
+              .filter(LinkableToken::supportsIntraLinks)
+              .flatMap(target -> source.accept(target).links().stream()
+                  .map(linkedLegs -> new LinkedLegs(
+                      linkableLeg(linkedLegs.source()),
+                      linkableLeg(linkedLegs.target()),
+                      linkedLegs.linkWeight()
+                  ))))
+          .collect(toList());
+    }
+
+    /**
+     * Links co-resolved tokens between this section and another using visitors used for intersection
+     * linking.
+     * @param linkableTokens all the tokens.
+     * @return the links between the tokens.
+     */
+    Collection<LinkedLegs> interLinks(LinkableTokens linkableTokens) {
       return cartesianProduct(linkableTokens(), linkableTokens.linkableTokens()).stream()
           .flatMap(pair -> pair.first().accept(pair.second()).links().stream()
               .map(linkedLegs -> new LinkedLegs(

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/AnyAirway.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/AnyAirway.java
@@ -31,6 +31,11 @@ final class AnyAirway implements LinkableToken {
   }
 
   @Override
+  public boolean supportsIntraLinks() {
+    return true;
+  }
+
+  @Override
   public void accept(LinkableTokenVisitor visitor) {
     visitor.visit(this);
   }
@@ -47,7 +52,8 @@ final class AnyAirway implements LinkableToken {
 
   @Override
   public Linker visit(AnyAirway airway) {
-    return multiLinker(airway);
+    return Linker.fixIdentMatch(airway, this)
+        .orElseTry(multiLinker(airway));
   }
 
   @Override

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/LinkableToken.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/LinkableToken.java
@@ -90,6 +90,18 @@ public interface LinkableToken extends LinkingVisitor {
   Collection<LinkedLegs> graphRepresentation();
 
   /**
+   * Returns true if this token type supports intra-section self-linking — i.e. co-resolved tokens of this type within the
+   * same {@link org.mitre.tdp.boogie.alg.resolve.ResolvedTokens} should be linked to each other.
+   *
+   * <p>This is meaningful for airways, where the same route identifier may resolve to multiple {@link org.mitre.tdp.boogie.Airway}
+   * objects whose subgraphs share a fix. For all other token types (procedures, fixes, airports) co-resolved tokens are
+   * unrelated and must not be cross-linked.
+   */
+  default boolean supportsIntraLinks() {
+    return false;
+  }
+
+  /**
    * Generic implementation of the visitor pattern for single-dispatch allowing various downstream collaborators to collect token
    * specific information (such as associated infrastructure, etc.).
    *

--- a/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/Linker.java
+++ b/boogie-routes/src/main/java/org/mitre/tdp/boogie/alg/chooser/graph/Linker.java
@@ -10,9 +10,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.mitre.caasd.commons.Distance;
@@ -43,6 +45,17 @@ public interface Linker {
    */
   static Linker tweak(Linker linker, DoubleUnaryOperator tweaker) {
     return new Tweaker(linker, tweaker);
+  }
+
+  /**
+   * A linker which returns {@link LinkedLegs} between all leg pairs of the left and right {@link LinkableToken}s where the
+   * associated fixes have matching identifiers.
+   *
+   * @param left  the token to link from
+   * @param right the token to link to
+   */
+  static Linker fixIdentMatch(LinkableToken left, LinkableToken right) {
+    return new FixIdentMatch(left, right);
   }
 
   /**
@@ -226,6 +239,42 @@ public interface Linker {
     public Collection<LinkedLegs> links() {
       return linker.links().stream()
           .map(linked -> new LinkedLegs(linked.source(), linked.target(), tweaker.applyAsDouble(linked.linkWeight())))
+          .toList();
+    }
+  }
+
+  final class FixIdentMatch implements Linker {
+
+    private final LinkableToken left;
+
+    private final LinkableToken right;
+
+    private FixIdentMatch(LinkableToken left, LinkableToken right) {
+      this.left = requireNonNull(left);
+      this.right = requireNonNull(right);
+    }
+
+    @Override
+    public Collection<LinkedLegs> links() {
+
+      Map<String, List<Leg>> rightLegsByFixIdentifier = withLocation(right.graphRepresentation()).stream()
+          .collect(Collectors.groupingBy(FixIdentMatch::fixIdentifier));
+
+      return withLocation(left.graphRepresentation()).stream()
+          .flatMap(leftLeg -> rightLegsByFixIdentifier.getOrDefault(fixIdentifier(leftLeg), List.of()).stream()
+              .map(rightLeg -> new LinkedLegs(leftLeg, rightLeg, LinkedLegs.SAME_ELEMENT_MATCH_WEIGHT)))
+          .toList();
+    }
+
+    private static String fixIdentifier(Leg leg) {
+      return leg.associatedFix().orElseThrow(IllegalStateException::new).fixIdentifier();
+    }
+
+    private static List<Leg> withLocation(Collection<LinkedLegs> linkedLegs) {
+      return linkedLegs.stream()
+          .flatMap(linked -> Stream.of(linked.source(), linked.target()))
+          .distinct()
+          .filter(leg -> leg.associatedFix().isPresent())
           .toList();
     }
   }

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/Airways.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/Airways.java
@@ -22,6 +22,16 @@ public final class Airways {
     Leg GGOLF = TF("GGOLF", 33.45582777777778, -84.33613333333332);
     return airway("J000", Arrays.asList(ZALLE, GGOLF));
   }
+  public static Airway J000B() {
+    Leg GGOLF = TF("GGOLF", 33.45582777777778, -84.33613333333332);
+    Leg NEXTT = TF("NEXTT", 33.46, -84.33613333333332);
+    return airway("J000", Arrays.asList(GGOLF, NEXTT));
+  }
+  public static Airway J000C() {
+    Leg UNRELATED = TF("UNRELATED", 50.0, 50.0);
+    Leg UNRELATED2 = TF("UNRELATED2", 51.0, 52.0);
+    return airway("J000", Arrays.asList(UNRELATED, UNRELATED2));
+  }
   public static Airway J121() {
     Leg CRG = TF("CRG", 30.338880555555555, -81.50992777777778);
     Leg MILIE = TF("MILIE", 31.328622222222222, -81.17371944444444);

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooserTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/GraphicalRouteChooserTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mitre.tdp.boogie.MockObjects.IF;
 import static org.mitre.tdp.boogie.MockObjects.TF;
 import static org.mitre.tdp.boogie.MockObjects.airport;
+import static org.mitre.tdp.boogie.MockObjects.airway;
+import static org.mitre.tdp.boogie.MockObjects.fix;
 import static org.mitre.tdp.boogie.MockObjects.transition;
 
 import java.util.Arrays;
@@ -18,7 +20,9 @@ import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 import org.junit.jupiter.api.Test;
+import org.mitre.caasd.commons.Pair;
 import org.mitre.tdp.boogie.Airport;
+import org.mitre.tdp.boogie.Airway;
 import org.mitre.tdp.boogie.Fix;
 import org.mitre.tdp.boogie.Leg;
 import org.mitre.tdp.boogie.MockObjects;
@@ -29,6 +33,7 @@ import org.mitre.tdp.boogie.TransitionType;
 import org.mitre.tdp.boogie.alg.LookupService;
 import org.mitre.tdp.boogie.alg.ResolvedLeg;
 import org.mitre.tdp.boogie.alg.chooser.graph.TokenMapper;
+import org.mitre.tdp.boogie.alg.resolve.ResolvedToken;
 import org.mitre.tdp.boogie.alg.resolve.ResolvedTokens;
 import org.mitre.tdp.boogie.alg.resolve.RouteTokenResolver;
 import org.mitre.tdp.boogie.alg.split.RouteToken;
@@ -58,6 +63,40 @@ class GraphicalRouteChooserTest {
         () -> assertEquals(1, conn.connectedSets().size(), msg),
         () -> assertEquals(6, conn.connectedSets().get(0).size(), msg)
     );
+  }
+
+  @Test
+  void testMixedResolvedTokensStillAddAirwayIntraLinks() {
+
+    Leg leftEntry = TF("LEFT", 0., 0.);
+    Leg leftBridge = TF("BRIDGE", 0., 1.);
+    Leg rightBridge = TF("BRIDGE", 10., 10.);
+    Leg rightExit = TF("RIGHT", 10., 11.);
+
+    Airway leftAirway = airway("MIXED", List.of(leftEntry, leftBridge));
+    Airway rightAirway = airway("MIXED", List.of(rightBridge, rightExit));
+    Airport airport = airport("MIXED", 50., 50.);
+    Fix fix = fix("MIXED", 60., 60.);
+
+    ResolvedTokens resolvedTokens = new ResolvedTokens(
+        RouteToken.standard("MIXED", 0.),
+        List.of(
+            ResolvedToken.standardAirway(leftAirway),
+            ResolvedToken.standardAirway(rightAirway),
+            ResolvedToken.standardFix(fix),
+            ResolvedToken.standardAirport(airport)
+        )
+    );
+
+    SimpleDirectedWeightedGraph<Leg, DefaultWeightedEdge> graph = routeChooser.constructRouteGraph(routeChooser.toLinkableTokens(List.of(resolvedTokens)));
+
+    boolean hasBridge = graph.edgeSet().stream()
+        .map(edge -> Pair.of(graph.getEdgeSource(edge), graph.getEdgeTarget(edge)))
+        .anyMatch(edge -> edge.first().associatedFix().map(Fix::fixIdentifier).filter("BRIDGE"::equals).isPresent()
+            && edge.second().associatedFix().map(Fix::fixIdentifier).filter("BRIDGE"::equals).isPresent()
+            && !edge.first().equals(edge.second()));
+
+    assertTrue(hasBridge, "Mixed co-resolved sections should still intra-link airway candidates sharing a fix identifier.");
   }
 
   @Test

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/graph/LinkerTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/chooser/graph/LinkerTest.java
@@ -34,6 +34,23 @@ class LinkerTest {
     assertEquals(expected, linkedLegs);
   }
 
+  @Test
+  void testFixIdentMatch() {
+
+    Leg l1 = newLeg("MATCH", LatLong.of(0., 0.));
+    Leg l2 = newLeg("OTHER", LatLong.of(0., 1.));
+    Leg l3 = newLeg("MATCH", LatLong.of(10., 10.));
+
+    LinkableToken r1 = newResolvedElement(l1, l2);
+    LinkableToken r2 = newResolvedElement(l3);
+
+    Collection<LinkedLegs> linkedLegs = Linker.fixIdentMatch(r1, r2).links();
+
+    List<LinkedLegs> expected = singletonList(new LinkedLegs(l1, l3, LinkedLegs.SAME_ELEMENT_MATCH_WEIGHT));
+
+    assertEquals(expected, linkedLegs);
+  }
+
   private LinkableToken newResolvedElement(Leg... legs) {
     List<LinkedLegs> linkedLegs = Stream.of(legs).map(leg -> new LinkedLegs(leg, leg, LinkedLegs.SAME_ELEMENT_MATCH_WEIGHT)).collect(toList());
 
@@ -44,6 +61,10 @@ class LinkerTest {
   }
 
   private Leg newLeg(LatLong location) {
-    return Leg.dfBuilder(Fix.builder().fixIdentifier("MOCK").latLong(location).build(), 0).build();
+    return newLeg("MOCK", location);
+  }
+
+  private Leg newLeg(String fixIdentifier, LatLong location) {
+    return Leg.dfBuilder(Fix.builder().fixIdentifier(fixIdentifier).latLong(location).build(), 0).build();
   }
 }

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/FluentRouteExpanderTest.java
@@ -198,7 +198,7 @@ class FluentRouteExpanderTest {
 
     FluentRouteExpander expander = newExpander(
         asList(start, end),
-        singletonList(Airways.J000()),
+        List.of(Airways.J000(), Airways.J000B(), Airways.J000C()),
         asList(Airports.KATL(), Airports.KMCO()),
         singletonList(PLMMR2.INSTANCE)
     );
@@ -208,6 +208,35 @@ class FluentRouteExpanderTest {
     assertAll("We want the airway to be taken over the sid",
         () -> assertEquals("J000", expandedRoute.legs().get(2).section(), "This better not be the sid"),
         () -> assertEquals("J000", expandedRoute.legs().get(3).section(), "This better not be the sid")
+    );
+  }
+
+  @Test
+  void testCrossAirwayChainTraversal() {
+    Fix start = fix("START", 33.3336, -84.7909);
+    Fix end = fix("ENDDD", 33.5496, -84.1357);
+    Fix nextt = fix("NEXTT", 33.46, -84.33613333333332);
+
+    String route = "KATL..START..ZALLE.J000.NEXTT..ENDDD..KMCO";
+
+    FluentRouteExpander expander = newExpander(
+        asList(start, end, nextt),
+        List.of(Airways.J000(), Airways.J000B(), Airways.J000C()),
+        asList(Airports.KATL(), Airports.KMCO()),
+        asList(PLMMR2.INSTANCE, STAR_FAKE.INSTANCE)
+    );
+
+    ExpandedRoute expandedRoute = expander.apply(route).orElseThrow();
+
+    assertAll("J000->J000B chain via GGOLF bridge; STAR_FAKE co-resolves with PLMMR2 SID POSSIBLY disasterous if we derp i",
+        () -> assertTrue(
+            expandedRoute.legs().stream().anyMatch(l -> l.associatedFix().map(f -> "NEXTT".equals(f.fixIdentifier())).orElse(false)),
+            "NEXTT (only on J000B) must appear in the expanded route"
+        ),
+        () -> assertTrue(
+            expandedRoute.legs().stream().noneMatch(l -> l.associatedFix().map(f -> "UNRELATED".equals(f.fixIdentifier())).orElse(false)),
+            "UNRELATED (J000C) must not appear in the expanded route"
+        )
     );
   }
 

--- a/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/InarticulateRouteExpanderTest.java
+++ b/boogie-routes/src/test/java/org/mitre/tdp/boogie/alg/facade/InarticulateRouteExpanderTest.java
@@ -154,7 +154,7 @@ class InarticulateRouteExpanderTest {
 
     InarticulateRouteExpander expander = newExpander(
         asList(start, end),
-        singletonList(Airways.J000()),
+        List.of(Airways.J000(), Airways.J000B(), Airways.J000C()),
         asList(Airports.KATL(), Airports.KMCO()),
         singletonList(PLMMR2.INSTANCE)
     );
@@ -164,6 +164,35 @@ class InarticulateRouteExpanderTest {
     assertAll("We want the airway to be taken over the sid",
         () -> assertEquals("J000", expandedRoute.legs().get(2).section(), "This better not be the sid"),
         () -> assertEquals("J000", expandedRoute.legs().get(3).section(), "This better not be the sid")
+    );
+  }
+
+  @Test
+  void testCrossAirwayChainTraversal() {
+    Fix start = fix("START", 33.3336, -84.7909);
+    Fix end = fix("ENDDD", 33.5496, -84.1357);
+    Fix nextt = fix("NEXTT", 33.46, -84.33613333333332);
+
+    String route = "KATL..START..ZALLE.J000.NEXTT..ENDDD..KMCO";
+
+    InarticulateRouteExpander expander = newExpander(
+        asList(start, end, nextt),
+        List.of(Airways.J000(), Airways.J000B(), Airways.J000C()),
+        asList(Airports.KATL(), Airports.KMCO()),
+        asList(PLMMR2.INSTANCE, STAR_FAKE.INSTANCE)
+    );
+
+    ExpandedRoute expandedRoute = expander.apply(route).orElseThrow();
+
+    assertAll("J000->J000B chain via GGOLF bridge; STAR_FAKE co-resolves with PLMMR2 SID POSSIBLY disasterous if we derp it",
+        () -> assertTrue(
+            expandedRoute.legs().stream().anyMatch(l -> l.associatedFix().map(f -> "NEXTT".equals(f.fixIdentifier())).orElse(false)),
+            "NEXTT (only on J000B) must appear in the expanded route"
+        ),
+        () -> assertTrue(
+            expandedRoute.legs().stream().noneMatch(l -> l.associatedFix().map(f -> "UNRELATED".equals(f.fixIdentifier())).orElse(false)),
+            "UNRELATED (J000C) must not appear in the expanded route"
+        )
     );
   }
 


### PR DESCRIPTION
Flight plans of FIX->AIWAY->FIX2  

When Airway resolves to 3 different airways as coded in source.  2 of those airways actually link up and form a continuous route. Also Fix 1 is on the airway and fix 2 is on airway 2.

FIX -> AIRWAY1 -> AIRWAY2 -> FIX2

Now for linkable tokens that support intra-links (Airways right now) we are going to allow them to form linked legs to the  other candidates in the resolved tokens list. Then you can see where the FIX links to best and get a route that way.

Like THIS:

<img width="1080" height="1716" alt="image" src="https://github.com/user-attachments/assets/6a228eb4-7025-4550-b1a0-996571c5ec12" />
