### PR TITLE
Complete the ARINC mapper factory

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ArincRecordConverterFactory.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ArincRecordConverterFactory.java
@@ -113,6 +113,7 @@ public final class ArincRecordConverterFactory {
         .headerOneConverter(new Header01Converter())
         .headerOneDelegator(new Header01Validator())
         .heliportConverter(new HeliportConverter())
+        .heliportDelegator(new HeliportValidator())
         .holdingPatternDelegator(new HoldingPatternValidator());
   }
 

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/model/TestConvertingArincRecordMapper.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/model/TestConvertingArincRecordMapper.java
@@ -2,6 +2,7 @@ package org.mitre.tdp.boogie.arinc.model;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -37,6 +38,11 @@ class TestConvertingArincRecordMapper {
         () -> assertEquals(6, recordsByType.getOrDefault(ArincVhfNavaid.class, emptyList()).size(), "VhfNavaid count"),
         () -> assertEquals(70, recordsByType.getOrDefault(ArincWaypoint.class, emptyList()).size(), "Waypoint count")
     );
+  }
+
+  @Test
+  void factoryBuildsCompleteV19Mapper() {
+    assertDoesNotThrow(() -> ArincRecordConverterFactory.mapperForVersion(ArincVersion.V19));
   }
 
   /**


### PR DESCRIPTION
## Problem

`ArincRecordConverterFactory.standardMapper()` registers the heliport **converter** but never the matching heliport **delegator**, so constructing the standard mapper — e.g. `ArincRecordConverterFactory.mapperForVersion(ArincVersion.V19)` — throws a `NullPointerException` from `DelegatingMapper`'s `requireNonNull(delegator)` before any record is processed. The consumer-side factory (`consumerForVersion`) wires heliports correctly; the mapper-side factory was simply missing the pair's other half.

## Change

- Register `HeliportValidator` as the heliport delegator in `standardMapper()`, matching the existing converter/delegator pairing used for every other record type.
- Add a regression test asserting `mapperForVersion(V19)` constructs without throwing.

## Notes

No behavior change for any mapper that could previously be built — this only makes the advertised factory method usable for V19, where heliport support is part of the standard record set.
