### PR TITLE
Cache converted ARINC record snapshots

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ConvertingArincRecordConsumer.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/model/ConvertingArincRecordConsumer.java
@@ -197,6 +197,7 @@ public final class ConvertingArincRecordConsumer implements Consumer<ArincRecord
     private final Function<ArincRecord, Optional<T>> converter;
 
     private final Collection<T> records;
+    private ImmutableCollection<T> snapshot;
 
     public DelegatableCollection(
         Predicate<ArincRecord> delegator,
@@ -208,13 +209,20 @@ public final class ConvertingArincRecordConsumer implements Consumer<ArincRecord
     }
 
     public ImmutableCollection<T> records() {
-      return ImmutableList.copyOf(records);
+      if (snapshot == null) {
+        snapshot = ImmutableList.copyOf(records);
+      }
+      return snapshot;
     }
 
     @Override
     public void accept(ArincRecord arincRecord) {
       checkArgument(delegator.test(arincRecord));
-      converter.apply(arincRecord).ifPresent(records::add);
+      converter.apply(arincRecord).ifPresent(record -> {
+        if (records.add(record)) {
+          snapshot = null;
+        }
+      });
     }
 
     @Override

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/model/TestConvertingArincRecordConsumer.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/model/TestConvertingArincRecordConsumer.java
@@ -2,6 +2,7 @@ package org.mitre.tdp.boogie.arinc.model;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.File;
 
@@ -35,6 +36,11 @@ class TestConvertingArincRecordConsumer {
         () -> assertEquals(6, testV18Consumer.arincVhfNavaids().size(), "VhfNavaid count"),
         () -> assertEquals(70, testV18Consumer.arincWaypoints().size(), "Waypoint count")
     );
+  }
+
+  @Test
+  void reusesImmutableRecordSnapshotBetweenWrites() {
+    assertSame(testV18Consumer.arincProcedureLegs(), testV18Consumer.arincProcedureLegs());
   }
 
   /**


### PR DESCRIPTION
## Problem

`ConvertingArincRecordConsumer`'s per-type accessors (`arincWaypoints()`, `arincProcedureLegs()`, …) build a fresh `ImmutableList.copyOf(records)` on **every call**. Downstream assembly (fix/terminal-area database construction, airport/procedure/airway assemblers) calls these accessors repeatedly, so parsing a worldwide 424 file pays an O(n) defensive copy — over hundreds of thousands of records for the large types — each time, purely as allocation and GC pressure.

## Change

Cache the immutable snapshot per record type and invalidate it only when the backing collection actually grows (a duplicate record — `records.add(...)` returning false — keeps the cached snapshot):

- `records()` returns the cached `ImmutableCollection` until a new unique record arrives.
- A repeated call between writes now returns the **same instance** (asserted by the new test), instead of an equal-but-new copy.

## Notes

The external contract is unchanged: callers still receive immutable collections and can never observe mutation. The win is for read-heavy consumers that interleave accessor calls with assembly over large datasets; write-then-read-once usage is unaffected.
