### PR TITLE
Add streaming ARINC parser callback

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/ArincFileParser.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/ArincFileParser.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.mitre.caasd.commons.fileutil.FileLineIterator;
@@ -52,13 +53,37 @@ public final class ArincFileParser implements Function<InputStream, Collection<A
 
   @Override
   public Collection<ArincRecord> apply(InputStream file) {
+    LinkedHashSet<ArincRecord> records = new LinkedHashSet<>();
+    parse(file, records::add);
+    return records;
+  }
+
+  /**
+   * Parses a file incrementally and sends each supported record to {@code sink}. Unlike
+   * {@link #apply(File)}, this method does not retain or de-duplicate the parsed records.
+   */
+  public void parse(File file, Consumer<? super ArincRecord> sink) {
     requireNonNull(file);
+    try (FileInputStream input = new FileInputStream(file)) {
+      parse(input, sink);
+    } catch (IOException e) {
+      throw DemotedException.demote("Error opening input 424 file: " + file, e);
+    }
+  }
+
+  /**
+   * Parses an ARINC 424 stream incrementally and sends each supported record to
+   * {@code sink}. The stream is consumed and closed, matching the existing
+   * {@link #apply(InputStream)} ownership contract.
+   *
+   * <p>The callback may convert, persist, or otherwise discard each record immediately,
+   * avoiding the full-file {@link LinkedHashSet} used by the collection-returning API.
+   */
+  public void parse(InputStream file, Consumer<? super ArincRecord> sink) {
+    requireNonNull(file);
+    requireNonNull(sink);
     try (FileLineIterator lineIterator = new FileLineIterator(new InputStreamReader(file))) {
-
-      LinkedHashSet<ArincRecord> records = new LinkedHashSet<>();
-      lineIterator.forEachRemaining(line -> recordParser.parse(line).ifPresent(records::add));
-
-      return records;
+      lineIterator.forEachRemaining(line -> recordParser.parse(line).ifPresent(sink));
     } catch (Exception e) {
       throw new IllegalArgumentException("Error during parse of ARINC 424 record stream.", e);
     }

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/TestArincFileParser.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/TestArincFileParser.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.mitre.tdp.boogie.arinc.v18.AirportSpec;
@@ -40,4 +41,13 @@ class TestArincFileParser {
     Collection<ArincRecord> records = fileParser.apply(arincTestFile);
     assertEquals(546, records.size(), "Expected 558 records given the explicitly configured list of specs in the test parser. Except for the 12 continuation records that should not parse into their primary record models");
   } //7 jfk runway continuations // 5 procedure legs with a continuation
+
+  @Test
+  void streamsSupportedRecordsToAConsumer() {
+    AtomicInteger records = new AtomicInteger();
+
+    fileParser.parse(arincTestFile, record -> records.incrementAndGet());
+
+    assertEquals(546, records.get());
+  }
 }


### PR DESCRIPTION
## Problem

`ArincFileParser`'s only API is collection-returning: `apply(File|InputStream)` accumulates every parsed record into a full-file `LinkedHashSet` before the caller sees anything. For worldwide 424 files (hundreds of MiB, millions of records) that transient set is pure peak-memory overhead for callers who want to convert, persist, or filter records incrementally — they immediately traverse the collection once and throw it away.

## Change

Add a streaming callback API alongside the existing one:

- `parse(File, Consumer<? super ArincRecord>)` and `parse(InputStream, Consumer<? super ArincRecord>)` deliver each supported record to the sink as it is parsed, retaining nothing and performing no de-duplication (documented on the methods).
- `apply(InputStream)` is refactored to delegate to `parse(stream, records::add)` with the same `LinkedHashSet`, so the collection API's ordering and de-duplication semantics are unchanged.
- Stream ownership matches the existing contract: the input is consumed and closed.

## Notes

Pairs naturally with `ConvertingArincRecordConsumer` (which is itself a `Consumer<ArincRecord>`): `parser.parse(file, consumer)` gives a single-pass, bounded-memory parse-and-convert pipeline without touching the existing collection-returning entry points.
