### PR TITLE
feat: assemble one model from multiple prioritized 424 sources

### DIFF
--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/ArincRecordParser.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/ArincRecordParser.java
@@ -62,7 +62,12 @@ public interface ArincRecordParser {
       requireNonNull(rawRecord, "Supplied ARINC-424 record should be non-null.");
 
       // at the expense of more operations... how strongly do we want to enforce none of our specs both match the same record...
-      Optional<RecordSpec> recordSpec = recordSpecs.stream().filter(rspec -> rspec.matchesRecord(rawRecord)).findFirst();
+      // records shorter than a spec (a stray blank or truncated line in a file) can't match it and would otherwise throw
+      // StringIndexOutOfBounds from the spec's column reads — skip them per this method's optional-return contract.
+      Optional<RecordSpec> recordSpec = recordSpecs.stream()
+          .filter(rspec -> rawRecord.length() >= rspec.recordLength())
+          .filter(rspec -> rspec.matchesRecord(rawRecord))
+          .findFirst();
 
       return recordSpec.map(spec -> createParsedRecord(rawRecord, spec));
     }

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/OneshotRecordParser.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/OneshotRecordParser.java
@@ -9,8 +9,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -46,10 +51,15 @@ import org.mitre.tdp.boogie.arinc.model.ArincAirport;
 import org.mitre.tdp.boogie.arinc.model.ArincAirwayLeg;
 import org.mitre.tdp.boogie.arinc.model.ArincControlledAirspaceLeg;
 import org.mitre.tdp.boogie.arinc.model.ArincFirUirLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincGnssLandingSystem;
 import org.mitre.tdp.boogie.arinc.model.ArincHeaderOne;
+import org.mitre.tdp.boogie.arinc.model.ArincHelipad;
 import org.mitre.tdp.boogie.arinc.model.ArincHeliport;
+import org.mitre.tdp.boogie.arinc.model.ArincHoldingPattern;
+import org.mitre.tdp.boogie.arinc.model.ArincLocalizerGlideSlope;
 import org.mitre.tdp.boogie.arinc.model.ArincNdbNavaid;
 import org.mitre.tdp.boogie.arinc.model.ArincProcedureLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincRunway;
 import org.mitre.tdp.boogie.arinc.model.ArincVhfNavaid;
 import org.mitre.tdp.boogie.arinc.model.ArincWaypoint;
 import org.mitre.tdp.boogie.arinc.model.ConvertingArincRecordConsumer;
@@ -131,10 +141,46 @@ public final class OneshotRecordParser<APT, RWY, FIX, LEG, TRS, AWY, PRC, AIR, A
   public ClientRecords<APT, FIX, AWY, PRC, AIR, HPT> assembleFrom(InputStream inputStream) {
     requireNonNull(inputStream);
 
-    ClientRecords.Builder<APT, FIX, AWY, PRC, AIR, HPT> records = new ClientRecords.Builder<>();
-
-    ArincRecordParser parser = ArincRecordParser.standard(version.specs());
     ConvertingArincRecordConsumer consumer = consumerForVersion(version);
+    if (!consumeInto(inputStream, consumer)) {
+      return new ClientRecords.Builder<APT, FIX, AWY, PRC, AIR, HPT>().build();
+    }
+    return assemble(RecordSets.of(consumer));
+  }
+
+  /**
+   * Assembles one collection of typed client records from <em>multiple</em> prioritized 424 sources — e.g. a hand-built patch
+   * file layered over a full published cycle, or local overrides layered over a database-served subset of a cycle.
+   *
+   * <p>Sources <strong>earlier in the list take precedence</strong>: when the same record (by its ARINC identity — the spec key
+   * fields of its type, e.g. {@code (airport, region, runway)} for a runway or {@code (airport, region, subsection, procedure,
+   * route type, transition, sequence)} for a procedure leg) appears in more than one source, the earliest source's version is
+   * kept and later ones are dropped. Records unique to any source are all retained. Precedence is deterministic and by record
+   * identity — a later source cannot "half override" a record by differing in content only.
+   *
+   * <p>All sources are merged <em>before</em> assembly, so cross-source references resolve: a patch source's procedure legs may
+   * reference fixes, navaids, or runways defined only in the base source and still assemble complete. The
+   * {@link ClientRecords#headerOne() header} is the first one present in source order.
+   *
+   * @param orderedSources the 424 sources, highest-precedence first; an empty list yields empty {@link ClientRecords}
+   */
+  public ClientRecords<APT, FIX, AWY, PRC, AIR, HPT> assembleFrom(List<InputStream> orderedSources) {
+    requireNonNull(orderedSources);
+
+    List<ConvertingArincRecordConsumer> consumers = new ArrayList<>(orderedSources.size());
+    for (InputStream source : orderedSources) {
+      ConvertingArincRecordConsumer consumer = consumerForVersion(version);
+      if (!consumeInto(source, consumer)) {
+        return new ClientRecords.Builder<APT, FIX, AWY, PRC, AIR, HPT>().build();
+      }
+      consumers.add(consumer);
+    }
+    return assemble(RecordSets.merged(consumers));
+  }
+
+  /** Parse and convert one source into the consumer; false (after logging) when the source cannot be read. */
+  private boolean consumeInto(InputStream inputStream, ConvertingArincRecordConsumer consumer) {
+    ArincRecordParser parser = ArincRecordParser.standard(version.specs());
 
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
       reader.lines()
@@ -142,47 +188,233 @@ public final class OneshotRecordParser<APT, RWY, FIX, LEG, TRS, AWY, PRC, AIR, A
           .flatMap(Optional::stream)
           .filter(keepRecord)
           .forEach(consumer);
+      return true;
     } catch (IOException e) {
       LOG.error("Could not parse the arinc text into memory", e);
-      return records.build();
+      return false;
     }
+  }
 
+  private ClientRecords<APT, FIX, AWY, PRC, AIR, HPT> assemble(RecordSets records) {
     LOG.debug("Finished parsing and converting supported record types.");
 
     ArincFixDatabase arincFixDatabase = ArincDatabaseFactory.newFixDatabase(
-        consumer.arincNdbNavaids(),
-        consumer.arincVhfNavaids(),
-        consumer.arincWaypoints(),
-        consumer.arincAirports(),
-        consumer.arincHoldingPatterns(),
-        consumer.arincHeliports()
+        records.ndbNavaids,
+        records.vhfNavaids,
+        records.waypoints,
+        records.airports,
+        records.holdingPatterns,
+        records.heliports
     );
     LOG.debug("Finished instantiation of FixDatabase.");
 
     ArincTerminalAreaDatabase arincTerminalAreaDatabase = ArincDatabaseFactory.newTerminalAreaDatabase(
-        consumer.arincAirports(),
-        consumer.arincRunways(),
-        consumer.arincLocalizerGlideSlopes(),
-        consumer.arincNdbNavaids(),
-        consumer.arincVhfNavaids(),
-        consumer.arincWaypoints(),
-        consumer.arincProcedureLegs(),
-        consumer.arincGnssLandingSystems(),
-        consumer.arincHelipads(),
-        consumer.arincHeliports()
+        records.airports,
+        records.runways,
+        records.localizerGlideSlopes,
+        records.ndbNavaids,
+        records.vhfNavaids,
+        records.waypoints,
+        records.procedureLegs,
+        records.gnssLandingSystems,
+        records.helipads,
+        records.heliports
     );
     LOG.debug("Finished instantiation of TerminalAreaDatabase.");
 
-    return records
-        .addAirports(assembleAirports(arincTerminalAreaDatabase, consumer.arincAirports()))
-        .addFixes(assembleFixes(consumer.arincWaypoints(), consumer.arincNdbNavaids(), consumer.arincVhfNavaids()))
-        .addAirways(assembleAirways(arincFixDatabase, consumer.arincAirwayLegs()))
-        .addProcedures(assembleProcedures(arincFixDatabase, arincTerminalAreaDatabase, consumer.arincProcedureLegs()))
-        .addFirUirs(assembleFirUirs(consumer.arincFirUirLegs()))
-        .addControlledAirspaces(assembleControlledAirspaces(arincFixDatabase, consumer.arincControlledAirspaceLegs()))
-        .headerOne(consumer.arincHeaderOne().orElse(null))
-        .addHeliport(assembleHeliports(arincTerminalAreaDatabase, consumer.arincHeliports()))
+    return new ClientRecords.Builder<APT, FIX, AWY, PRC, AIR, HPT>()
+        .addAirports(assembleAirports(arincTerminalAreaDatabase, records.airports))
+        .addFixes(assembleFixes(records.waypoints, records.ndbNavaids, records.vhfNavaids))
+        .addAirways(assembleAirways(arincFixDatabase, records.airwayLegs))
+        .addProcedures(assembleProcedures(arincFixDatabase, arincTerminalAreaDatabase, records.procedureLegs))
+        .addFirUirs(assembleFirUirs(records.firUirLegs))
+        .addControlledAirspaces(assembleControlledAirspaces(arincFixDatabase, records.controlledAirspaceLegs))
+        .headerOne(records.headerOne.orElse(null))
+        .addHeliport(assembleHeliports(arincTerminalAreaDatabase, records.heliports))
         .build();
+  }
+
+  /**
+   * The converted-record collections assembly consumes, either passed straight through from one consumer or merged across
+   * several prioritized consumers with earliest-source-wins resolution per record identity.
+   */
+  private static final class RecordSets {
+
+    private final Collection<ArincAirport> airports;
+    private final Collection<ArincRunway> runways;
+    private final Collection<ArincLocalizerGlideSlope> localizerGlideSlopes;
+    private final Collection<ArincNdbNavaid> ndbNavaids;
+    private final Collection<ArincVhfNavaid> vhfNavaids;
+    private final Collection<ArincWaypoint> waypoints;
+    private final Collection<ArincAirwayLeg> airwayLegs;
+    private final Collection<ArincProcedureLeg> procedureLegs;
+    private final Collection<ArincGnssLandingSystem> gnssLandingSystems;
+    private final Collection<ArincHoldingPattern> holdingPatterns;
+    private final Collection<ArincFirUirLeg> firUirLegs;
+    private final Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs;
+    private final Collection<ArincHelipad> helipads;
+    private final Collection<ArincHeliport> heliports;
+    private final Optional<ArincHeaderOne> headerOne;
+
+    private RecordSets(
+        Collection<ArincAirport> airports,
+        Collection<ArincRunway> runways,
+        Collection<ArincLocalizerGlideSlope> localizerGlideSlopes,
+        Collection<ArincNdbNavaid> ndbNavaids,
+        Collection<ArincVhfNavaid> vhfNavaids,
+        Collection<ArincWaypoint> waypoints,
+        Collection<ArincAirwayLeg> airwayLegs,
+        Collection<ArincProcedureLeg> procedureLegs,
+        Collection<ArincGnssLandingSystem> gnssLandingSystems,
+        Collection<ArincHoldingPattern> holdingPatterns,
+        Collection<ArincFirUirLeg> firUirLegs,
+        Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs,
+        Collection<ArincHelipad> helipads,
+        Collection<ArincHeliport> heliports,
+        Optional<ArincHeaderOne> headerOne) {
+      this.airports = airports;
+      this.runways = runways;
+      this.localizerGlideSlopes = localizerGlideSlopes;
+      this.ndbNavaids = ndbNavaids;
+      this.vhfNavaids = vhfNavaids;
+      this.waypoints = waypoints;
+      this.airwayLegs = airwayLegs;
+      this.procedureLegs = procedureLegs;
+      this.gnssLandingSystems = gnssLandingSystems;
+      this.holdingPatterns = holdingPatterns;
+      this.firUirLegs = firUirLegs;
+      this.controlledAirspaceLegs = controlledAirspaceLegs;
+      this.helipads = helipads;
+      this.heliports = heliports;
+      this.headerOne = headerOne;
+    }
+
+    /** One source: the consumer's collections pass straight through, identical to historical single-stream behavior. */
+    static RecordSets of(ConvertingArincRecordConsumer consumer) {
+      return new RecordSets(
+          consumer.arincAirports(),
+          consumer.arincRunways(),
+          consumer.arincLocalizerGlideSlopes(),
+          consumer.arincNdbNavaids(),
+          consumer.arincVhfNavaids(),
+          consumer.arincWaypoints(),
+          consumer.arincAirwayLegs(),
+          consumer.arincProcedureLegs(),
+          consumer.arincGnssLandingSystems(),
+          consumer.arincHoldingPatterns(),
+          consumer.arincFirUirLegs(),
+          consumer.arincControlledAirspaceLegs(),
+          consumer.arincHelipads(),
+          consumer.arincHeliports(),
+          consumer.arincHeaderOne()
+      );
+    }
+
+    /** Several prioritized sources: earliest source wins per record identity; the header is the first one present. */
+    static RecordSets merged(List<ConvertingArincRecordConsumer> ordered) {
+      return new RecordSets(
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirports, RecordSets::airportIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincRunways, RecordSets::runwayIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincLocalizerGlideSlopes, RecordSets::localizerIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincNdbNavaids, RecordSets::ndbIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincVhfNavaids, RecordSets::vhfIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincWaypoints, RecordSets::waypointIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirwayLegs, RecordSets::airwayLegIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincProcedureLegs, RecordSets::procedureLegIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincGnssLandingSystems, RecordSets::glsIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHoldingPatterns, RecordSets::holdingPatternIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincFirUirLegs, RecordSets::firUirLegIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincControlledAirspaceLegs, RecordSets::controlledAirspaceLegIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHelipads, RecordSets::helipadIdentity),
+          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHeliports, RecordSets::heliportIdentity),
+          ordered.stream().map(ConvertingArincRecordConsumer::arincHeaderOne).flatMap(Optional::stream).findFirst()
+      );
+    }
+
+    /**
+     * Union the sources' records of one type, keeping the first record seen for each identity — so earlier (higher-precedence)
+     * sources shadow later ones, and a duplicated identity within one source keeps its first occurrence.
+     */
+    private static <T> Collection<T> mergeByIdentity(List<ConvertingArincRecordConsumer> ordered,
+        Function<ConvertingArincRecordConsumer, Collection<T>> records, Function<T, Object> identity) {
+
+      Map<Object, T> merged = new LinkedHashMap<>();
+      for (ConvertingArincRecordConsumer source : ordered) {
+        for (T record : records.apply(source)) {
+          merged.putIfAbsent(identity.apply(record), record);
+        }
+      }
+      return List.copyOf(merged.values());
+    }
+
+    // Record identities: the ARINC spec key fields of each converted type. Two records with equal identity describe the same
+    // logical entity (possibly with different content) and are candidates for cross-source shadowing.
+
+    private static Object airportIdentity(ArincAirport airport) {
+      return Arrays.asList(airport.airportIdentifier(), airport.airportIcaoRegion());
+    }
+
+    private static Object runwayIdentity(ArincRunway runway) {
+      return Arrays.asList(runway.airportIdentifier(), runway.airportIcaoRegion(), runway.runwayIdentifier());
+    }
+
+    private static Object localizerIdentity(ArincLocalizerGlideSlope localizer) {
+      return Arrays.asList(localizer.airportIdentifier(), localizer.airportIcaoRegion(),
+          localizer.localizerIdentifier(), localizer.runwayIdentifier());
+    }
+
+    private static Object ndbIdentity(ArincNdbNavaid ndb) {
+      return Arrays.asList(ndb.sectionCode(), ndb.subSectionCode().orElse(null),
+          ndb.airportIdentifier().orElse(null), ndb.ndbIdentifier(), ndb.ndbIcaoRegion());
+    }
+
+    private static Object vhfIdentity(ArincVhfNavaid vhf) {
+      return Arrays.asList(vhf.airportIdentifier().orElse(null), vhf.vhfIdentifier(), vhf.vhfIcaoRegion());
+    }
+
+    private static Object waypointIdentity(ArincWaypoint waypoint) {
+      return Arrays.asList(waypoint.sectionCode(), waypoint.subSectionCode().orElse(null),
+          waypoint.airportIdentifier().orElse(null), waypoint.waypointIdentifier(), waypoint.waypointIcaoRegion());
+    }
+
+    private static Object airwayLegIdentity(ArincAirwayLeg leg) {
+      return Arrays.asList(leg.routeIdentifier(), leg.sequenceNumber(), leg.fixIdentifier(), leg.fixIcaoRegion());
+    }
+
+    private static Object procedureLegIdentity(ArincProcedureLeg leg) {
+      return Arrays.asList(leg.airportIdentifier(), leg.airportIcaoRegion(), leg.subSectionCode().orElse(null),
+          leg.sidStarIdentifier(), leg.routeType(), leg.transitionIdentifier().orElse(null), leg.sequenceNumber());
+    }
+
+    private static Object glsIdentity(ArincGnssLandingSystem gls) {
+      return Arrays.asList(gls.airportIdentifier(), gls.airportIcaoRegion(),
+          gls.glsRefPathIdentifier(), gls.runwayIdentifier());
+    }
+
+    private static Object holdingPatternIdentity(ArincHoldingPattern holdingPattern) {
+      return Arrays.asList(holdingPattern.regionCode().orElse(null), holdingPattern.icaoRegion().orElse(null),
+          holdingPattern.fixIdentifier(), holdingPattern.fixIcaoRegion(),
+          holdingPattern.duplicateIdentifier().orElse(null));
+    }
+
+    private static Object firUirLegIdentity(ArincFirUirLeg leg) {
+      return Arrays.asList(leg.firUirIdentifier(), leg.firUirAddress().orElse(null),
+          leg.firUirIndicator(), leg.sequenceNumber());
+    }
+
+    private static Object controlledAirspaceLegIdentity(ArincControlledAirspaceLeg leg) {
+      return Arrays.asList(leg.icaoRegion(), leg.airspaceType(), leg.airspaceCenter(),
+          leg.multipleCode().orElse(null), leg.sequenceNumber());
+    }
+
+    private static Object helipadIdentity(ArincHelipad helipad) {
+      return Arrays.asList(helipad.airportHeliportIdentifier(), helipad.icaoCode(), helipad.helipadIdentifier());
+    }
+
+    private static Object heliportIdentity(ArincHeliport heliport) {
+      return Arrays.asList(heliport.heliportIdentifier(), heliport.heliportIcaoRegion(),
+          heliport.padIdentifier().orElse(null));
+    }
   }
 
   private Collection<PRC> assembleProcedures(ArincFixDatabase arincFixDatabase, ArincTerminalAreaDatabase arincTerminalAreaDatabase,

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/OneshotRecordParser.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/OneshotRecordParser.java
@@ -9,13 +9,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -51,15 +47,10 @@ import org.mitre.tdp.boogie.arinc.model.ArincAirport;
 import org.mitre.tdp.boogie.arinc.model.ArincAirwayLeg;
 import org.mitre.tdp.boogie.arinc.model.ArincControlledAirspaceLeg;
 import org.mitre.tdp.boogie.arinc.model.ArincFirUirLeg;
-import org.mitre.tdp.boogie.arinc.model.ArincGnssLandingSystem;
 import org.mitre.tdp.boogie.arinc.model.ArincHeaderOne;
-import org.mitre.tdp.boogie.arinc.model.ArincHelipad;
 import org.mitre.tdp.boogie.arinc.model.ArincHeliport;
-import org.mitre.tdp.boogie.arinc.model.ArincHoldingPattern;
-import org.mitre.tdp.boogie.arinc.model.ArincLocalizerGlideSlope;
 import org.mitre.tdp.boogie.arinc.model.ArincNdbNavaid;
 import org.mitre.tdp.boogie.arinc.model.ArincProcedureLeg;
-import org.mitre.tdp.boogie.arinc.model.ArincRunway;
 import org.mitre.tdp.boogie.arinc.model.ArincVhfNavaid;
 import org.mitre.tdp.boogie.arinc.model.ArincWaypoint;
 import org.mitre.tdp.boogie.arinc.model.ConvertingArincRecordConsumer;
@@ -199,222 +190,39 @@ public final class OneshotRecordParser<APT, RWY, FIX, LEG, TRS, AWY, PRC, AIR, A
     LOG.debug("Finished parsing and converting supported record types.");
 
     ArincFixDatabase arincFixDatabase = ArincDatabaseFactory.newFixDatabase(
-        records.ndbNavaids,
-        records.vhfNavaids,
-        records.waypoints,
-        records.airports,
-        records.holdingPatterns,
-        records.heliports
+        records.ndbNavaids(),
+        records.vhfNavaids(),
+        records.waypoints(),
+        records.airports(),
+        records.holdingPatterns(),
+        records.heliports()
     );
     LOG.debug("Finished instantiation of FixDatabase.");
 
     ArincTerminalAreaDatabase arincTerminalAreaDatabase = ArincDatabaseFactory.newTerminalAreaDatabase(
-        records.airports,
-        records.runways,
-        records.localizerGlideSlopes,
-        records.ndbNavaids,
-        records.vhfNavaids,
-        records.waypoints,
-        records.procedureLegs,
-        records.gnssLandingSystems,
-        records.helipads,
-        records.heliports
+        records.airports(),
+        records.runways(),
+        records.localizerGlideSlopes(),
+        records.ndbNavaids(),
+        records.vhfNavaids(),
+        records.waypoints(),
+        records.procedureLegs(),
+        records.gnssLandingSystems(),
+        records.helipads(),
+        records.heliports()
     );
     LOG.debug("Finished instantiation of TerminalAreaDatabase.");
 
     return new ClientRecords.Builder<APT, FIX, AWY, PRC, AIR, HPT>()
-        .addAirports(assembleAirports(arincTerminalAreaDatabase, records.airports))
-        .addFixes(assembleFixes(records.waypoints, records.ndbNavaids, records.vhfNavaids))
-        .addAirways(assembleAirways(arincFixDatabase, records.airwayLegs))
-        .addProcedures(assembleProcedures(arincFixDatabase, arincTerminalAreaDatabase, records.procedureLegs))
-        .addFirUirs(assembleFirUirs(records.firUirLegs))
-        .addControlledAirspaces(assembleControlledAirspaces(arincFixDatabase, records.controlledAirspaceLegs))
-        .headerOne(records.headerOne.orElse(null))
-        .addHeliport(assembleHeliports(arincTerminalAreaDatabase, records.heliports))
+        .addAirports(assembleAirports(arincTerminalAreaDatabase, records.airports()))
+        .addFixes(assembleFixes(records.waypoints(), records.ndbNavaids(), records.vhfNavaids()))
+        .addAirways(assembleAirways(arincFixDatabase, records.airwayLegs()))
+        .addProcedures(assembleProcedures(arincFixDatabase, arincTerminalAreaDatabase, records.procedureLegs()))
+        .addFirUirs(assembleFirUirs(records.firUirLegs()))
+        .addControlledAirspaces(assembleControlledAirspaces(arincFixDatabase, records.controlledAirspaceLegs()))
+        .headerOne(records.headerOne().orElse(null))
+        .addHeliport(assembleHeliports(arincTerminalAreaDatabase, records.heliports()))
         .build();
-  }
-
-  /**
-   * The converted-record collections assembly consumes, either passed straight through from one consumer or merged across
-   * several prioritized consumers with earliest-source-wins resolution per record identity.
-   */
-  private static final class RecordSets {
-
-    private final Collection<ArincAirport> airports;
-    private final Collection<ArincRunway> runways;
-    private final Collection<ArincLocalizerGlideSlope> localizerGlideSlopes;
-    private final Collection<ArincNdbNavaid> ndbNavaids;
-    private final Collection<ArincVhfNavaid> vhfNavaids;
-    private final Collection<ArincWaypoint> waypoints;
-    private final Collection<ArincAirwayLeg> airwayLegs;
-    private final Collection<ArincProcedureLeg> procedureLegs;
-    private final Collection<ArincGnssLandingSystem> gnssLandingSystems;
-    private final Collection<ArincHoldingPattern> holdingPatterns;
-    private final Collection<ArincFirUirLeg> firUirLegs;
-    private final Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs;
-    private final Collection<ArincHelipad> helipads;
-    private final Collection<ArincHeliport> heliports;
-    private final Optional<ArincHeaderOne> headerOne;
-
-    private RecordSets(
-        Collection<ArincAirport> airports,
-        Collection<ArincRunway> runways,
-        Collection<ArincLocalizerGlideSlope> localizerGlideSlopes,
-        Collection<ArincNdbNavaid> ndbNavaids,
-        Collection<ArincVhfNavaid> vhfNavaids,
-        Collection<ArincWaypoint> waypoints,
-        Collection<ArincAirwayLeg> airwayLegs,
-        Collection<ArincProcedureLeg> procedureLegs,
-        Collection<ArincGnssLandingSystem> gnssLandingSystems,
-        Collection<ArincHoldingPattern> holdingPatterns,
-        Collection<ArincFirUirLeg> firUirLegs,
-        Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs,
-        Collection<ArincHelipad> helipads,
-        Collection<ArincHeliport> heliports,
-        Optional<ArincHeaderOne> headerOne) {
-      this.airports = airports;
-      this.runways = runways;
-      this.localizerGlideSlopes = localizerGlideSlopes;
-      this.ndbNavaids = ndbNavaids;
-      this.vhfNavaids = vhfNavaids;
-      this.waypoints = waypoints;
-      this.airwayLegs = airwayLegs;
-      this.procedureLegs = procedureLegs;
-      this.gnssLandingSystems = gnssLandingSystems;
-      this.holdingPatterns = holdingPatterns;
-      this.firUirLegs = firUirLegs;
-      this.controlledAirspaceLegs = controlledAirspaceLegs;
-      this.helipads = helipads;
-      this.heliports = heliports;
-      this.headerOne = headerOne;
-    }
-
-    /** One source: the consumer's collections pass straight through, identical to historical single-stream behavior. */
-    static RecordSets of(ConvertingArincRecordConsumer consumer) {
-      return new RecordSets(
-          consumer.arincAirports(),
-          consumer.arincRunways(),
-          consumer.arincLocalizerGlideSlopes(),
-          consumer.arincNdbNavaids(),
-          consumer.arincVhfNavaids(),
-          consumer.arincWaypoints(),
-          consumer.arincAirwayLegs(),
-          consumer.arincProcedureLegs(),
-          consumer.arincGnssLandingSystems(),
-          consumer.arincHoldingPatterns(),
-          consumer.arincFirUirLegs(),
-          consumer.arincControlledAirspaceLegs(),
-          consumer.arincHelipads(),
-          consumer.arincHeliports(),
-          consumer.arincHeaderOne()
-      );
-    }
-
-    /** Several prioritized sources: earliest source wins per record identity; the header is the first one present. */
-    static RecordSets merged(List<ConvertingArincRecordConsumer> ordered) {
-      return new RecordSets(
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirports, RecordSets::airportIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincRunways, RecordSets::runwayIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincLocalizerGlideSlopes, RecordSets::localizerIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincNdbNavaids, RecordSets::ndbIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincVhfNavaids, RecordSets::vhfIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincWaypoints, RecordSets::waypointIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirwayLegs, RecordSets::airwayLegIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincProcedureLegs, RecordSets::procedureLegIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincGnssLandingSystems, RecordSets::glsIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHoldingPatterns, RecordSets::holdingPatternIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincFirUirLegs, RecordSets::firUirLegIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincControlledAirspaceLegs, RecordSets::controlledAirspaceLegIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHelipads, RecordSets::helipadIdentity),
-          mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHeliports, RecordSets::heliportIdentity),
-          ordered.stream().map(ConvertingArincRecordConsumer::arincHeaderOne).flatMap(Optional::stream).findFirst()
-      );
-    }
-
-    /**
-     * Union the sources' records of one type, keeping the first record seen for each identity — so earlier (higher-precedence)
-     * sources shadow later ones, and a duplicated identity within one source keeps its first occurrence.
-     */
-    private static <T> Collection<T> mergeByIdentity(List<ConvertingArincRecordConsumer> ordered,
-        Function<ConvertingArincRecordConsumer, Collection<T>> records, Function<T, Object> identity) {
-
-      Map<Object, T> merged = new LinkedHashMap<>();
-      for (ConvertingArincRecordConsumer source : ordered) {
-        for (T record : records.apply(source)) {
-          merged.putIfAbsent(identity.apply(record), record);
-        }
-      }
-      return List.copyOf(merged.values());
-    }
-
-    // Record identities: the ARINC spec key fields of each converted type. Two records with equal identity describe the same
-    // logical entity (possibly with different content) and are candidates for cross-source shadowing.
-
-    private static Object airportIdentity(ArincAirport airport) {
-      return Arrays.asList(airport.airportIdentifier(), airport.airportIcaoRegion());
-    }
-
-    private static Object runwayIdentity(ArincRunway runway) {
-      return Arrays.asList(runway.airportIdentifier(), runway.airportIcaoRegion(), runway.runwayIdentifier());
-    }
-
-    private static Object localizerIdentity(ArincLocalizerGlideSlope localizer) {
-      return Arrays.asList(localizer.airportIdentifier(), localizer.airportIcaoRegion(),
-          localizer.localizerIdentifier(), localizer.runwayIdentifier());
-    }
-
-    private static Object ndbIdentity(ArincNdbNavaid ndb) {
-      return Arrays.asList(ndb.sectionCode(), ndb.subSectionCode().orElse(null),
-          ndb.airportIdentifier().orElse(null), ndb.ndbIdentifier(), ndb.ndbIcaoRegion());
-    }
-
-    private static Object vhfIdentity(ArincVhfNavaid vhf) {
-      return Arrays.asList(vhf.airportIdentifier().orElse(null), vhf.vhfIdentifier(), vhf.vhfIcaoRegion());
-    }
-
-    private static Object waypointIdentity(ArincWaypoint waypoint) {
-      return Arrays.asList(waypoint.sectionCode(), waypoint.subSectionCode().orElse(null),
-          waypoint.airportIdentifier().orElse(null), waypoint.waypointIdentifier(), waypoint.waypointIcaoRegion());
-    }
-
-    private static Object airwayLegIdentity(ArincAirwayLeg leg) {
-      return Arrays.asList(leg.routeIdentifier(), leg.sequenceNumber(), leg.fixIdentifier(), leg.fixIcaoRegion());
-    }
-
-    private static Object procedureLegIdentity(ArincProcedureLeg leg) {
-      return Arrays.asList(leg.airportIdentifier(), leg.airportIcaoRegion(), leg.subSectionCode().orElse(null),
-          leg.sidStarIdentifier(), leg.routeType(), leg.transitionIdentifier().orElse(null), leg.sequenceNumber());
-    }
-
-    private static Object glsIdentity(ArincGnssLandingSystem gls) {
-      return Arrays.asList(gls.airportIdentifier(), gls.airportIcaoRegion(),
-          gls.glsRefPathIdentifier(), gls.runwayIdentifier());
-    }
-
-    private static Object holdingPatternIdentity(ArincHoldingPattern holdingPattern) {
-      return Arrays.asList(holdingPattern.regionCode().orElse(null), holdingPattern.icaoRegion().orElse(null),
-          holdingPattern.fixIdentifier(), holdingPattern.fixIcaoRegion(),
-          holdingPattern.duplicateIdentifier().orElse(null));
-    }
-
-    private static Object firUirLegIdentity(ArincFirUirLeg leg) {
-      return Arrays.asList(leg.firUirIdentifier(), leg.firUirAddress().orElse(null),
-          leg.firUirIndicator(), leg.sequenceNumber());
-    }
-
-    private static Object controlledAirspaceLegIdentity(ArincControlledAirspaceLeg leg) {
-      return Arrays.asList(leg.icaoRegion(), leg.airspaceType(), leg.airspaceCenter(),
-          leg.multipleCode().orElse(null), leg.sequenceNumber());
-    }
-
-    private static Object helipadIdentity(ArincHelipad helipad) {
-      return Arrays.asList(helipad.airportHeliportIdentifier(), helipad.icaoCode(), helipad.helipadIdentifier());
-    }
-
-    private static Object heliportIdentity(ArincHeliport heliport) {
-      return Arrays.asList(heliport.heliportIdentifier(), heliport.heliportIcaoRegion(),
-          heliport.padIdentifier().orElse(null));
-    }
   }
 
   private Collection<PRC> assembleProcedures(ArincFixDatabase arincFixDatabase, ArincTerminalAreaDatabase arincTerminalAreaDatabase,

--- a/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/RecordSets.java
+++ b/boogie-arinc/src/main/java/org/mitre/tdp/boogie/arinc/RecordSets.java
@@ -1,0 +1,270 @@
+package org.mitre.tdp.boogie.arinc;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.mitre.tdp.boogie.arinc.model.ArincAirport;
+import org.mitre.tdp.boogie.arinc.model.ArincAirwayLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincControlledAirspaceLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincFirUirLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincGnssLandingSystem;
+import org.mitre.tdp.boogie.arinc.model.ArincHeaderOne;
+import org.mitre.tdp.boogie.arinc.model.ArincHelipad;
+import org.mitre.tdp.boogie.arinc.model.ArincHeliport;
+import org.mitre.tdp.boogie.arinc.model.ArincHoldingPattern;
+import org.mitre.tdp.boogie.arinc.model.ArincLocalizerGlideSlope;
+import org.mitre.tdp.boogie.arinc.model.ArincNdbNavaid;
+import org.mitre.tdp.boogie.arinc.model.ArincProcedureLeg;
+import org.mitre.tdp.boogie.arinc.model.ArincRunway;
+import org.mitre.tdp.boogie.arinc.model.ArincVhfNavaid;
+import org.mitre.tdp.boogie.arinc.model.ArincWaypoint;
+import org.mitre.tdp.boogie.arinc.model.ConvertingArincRecordConsumer;
+
+/**
+ * The converted-record collections {@link OneshotRecordParser} assembles from, either passed straight through from one
+ * consumer (identical to historical single-stream behavior) or merged across several prioritized consumers with
+ * earliest-source-wins resolution per record identity.
+ *
+ * <p>Record identity is the ARINC spec key fields of each converted type — two records with equal identity describe the same
+ * logical entity (possibly with different content) and are candidates for cross-source shadowing.
+ */
+final class RecordSets {
+
+  private final Collection<ArincAirport> airports;
+  private final Collection<ArincRunway> runways;
+  private final Collection<ArincLocalizerGlideSlope> localizerGlideSlopes;
+  private final Collection<ArincNdbNavaid> ndbNavaids;
+  private final Collection<ArincVhfNavaid> vhfNavaids;
+  private final Collection<ArincWaypoint> waypoints;
+  private final Collection<ArincAirwayLeg> airwayLegs;
+  private final Collection<ArincProcedureLeg> procedureLegs;
+  private final Collection<ArincGnssLandingSystem> gnssLandingSystems;
+  private final Collection<ArincHoldingPattern> holdingPatterns;
+  private final Collection<ArincFirUirLeg> firUirLegs;
+  private final Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs;
+  private final Collection<ArincHelipad> helipads;
+  private final Collection<ArincHeliport> heliports;
+  private final Optional<ArincHeaderOne> headerOne;
+
+  private RecordSets(
+      Collection<ArincAirport> airports,
+      Collection<ArincRunway> runways,
+      Collection<ArincLocalizerGlideSlope> localizerGlideSlopes,
+      Collection<ArincNdbNavaid> ndbNavaids,
+      Collection<ArincVhfNavaid> vhfNavaids,
+      Collection<ArincWaypoint> waypoints,
+      Collection<ArincAirwayLeg> airwayLegs,
+      Collection<ArincProcedureLeg> procedureLegs,
+      Collection<ArincGnssLandingSystem> gnssLandingSystems,
+      Collection<ArincHoldingPattern> holdingPatterns,
+      Collection<ArincFirUirLeg> firUirLegs,
+      Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs,
+      Collection<ArincHelipad> helipads,
+      Collection<ArincHeliport> heliports,
+      Optional<ArincHeaderOne> headerOne) {
+    this.airports = airports;
+    this.runways = runways;
+    this.localizerGlideSlopes = localizerGlideSlopes;
+    this.ndbNavaids = ndbNavaids;
+    this.vhfNavaids = vhfNavaids;
+    this.waypoints = waypoints;
+    this.airwayLegs = airwayLegs;
+    this.procedureLegs = procedureLegs;
+    this.gnssLandingSystems = gnssLandingSystems;
+    this.holdingPatterns = holdingPatterns;
+    this.firUirLegs = firUirLegs;
+    this.controlledAirspaceLegs = controlledAirspaceLegs;
+    this.helipads = helipads;
+    this.heliports = heliports;
+    this.headerOne = headerOne;
+  }
+
+  /** One source: the consumer's collections pass straight through, identical to historical single-stream behavior. */
+  static RecordSets of(ConvertingArincRecordConsumer consumer) {
+    return new RecordSets(
+        consumer.arincAirports(),
+        consumer.arincRunways(),
+        consumer.arincLocalizerGlideSlopes(),
+        consumer.arincNdbNavaids(),
+        consumer.arincVhfNavaids(),
+        consumer.arincWaypoints(),
+        consumer.arincAirwayLegs(),
+        consumer.arincProcedureLegs(),
+        consumer.arincGnssLandingSystems(),
+        consumer.arincHoldingPatterns(),
+        consumer.arincFirUirLegs(),
+        consumer.arincControlledAirspaceLegs(),
+        consumer.arincHelipads(),
+        consumer.arincHeliports(),
+        consumer.arincHeaderOne()
+    );
+  }
+
+  /** Several prioritized sources: earliest source wins per record identity; the header is the first one present. */
+  static RecordSets merged(List<ConvertingArincRecordConsumer> ordered) {
+    return new RecordSets(
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirports, RecordSets::airportIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincRunways, RecordSets::runwayIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincLocalizerGlideSlopes, RecordSets::localizerIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincNdbNavaids, RecordSets::ndbIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincVhfNavaids, RecordSets::vhfIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincWaypoints, RecordSets::waypointIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincAirwayLegs, RecordSets::airwayLegIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincProcedureLegs, RecordSets::procedureLegIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincGnssLandingSystems, RecordSets::glsIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHoldingPatterns, RecordSets::holdingPatternIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincFirUirLegs, RecordSets::firUirLegIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincControlledAirspaceLegs, RecordSets::controlledAirspaceLegIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHelipads, RecordSets::helipadIdentity),
+        mergeByIdentity(ordered, ConvertingArincRecordConsumer::arincHeliports, RecordSets::heliportIdentity),
+        ordered.stream().map(ConvertingArincRecordConsumer::arincHeaderOne).flatMap(Optional::stream).findFirst()
+    );
+  }
+
+  Collection<ArincAirport> airports() {
+    return airports;
+  }
+
+  Collection<ArincRunway> runways() {
+    return runways;
+  }
+
+  Collection<ArincLocalizerGlideSlope> localizerGlideSlopes() {
+    return localizerGlideSlopes;
+  }
+
+  Collection<ArincNdbNavaid> ndbNavaids() {
+    return ndbNavaids;
+  }
+
+  Collection<ArincVhfNavaid> vhfNavaids() {
+    return vhfNavaids;
+  }
+
+  Collection<ArincWaypoint> waypoints() {
+    return waypoints;
+  }
+
+  Collection<ArincAirwayLeg> airwayLegs() {
+    return airwayLegs;
+  }
+
+  Collection<ArincProcedureLeg> procedureLegs() {
+    return procedureLegs;
+  }
+
+  Collection<ArincGnssLandingSystem> gnssLandingSystems() {
+    return gnssLandingSystems;
+  }
+
+  Collection<ArincHoldingPattern> holdingPatterns() {
+    return holdingPatterns;
+  }
+
+  Collection<ArincFirUirLeg> firUirLegs() {
+    return firUirLegs;
+  }
+
+  Collection<ArincControlledAirspaceLeg> controlledAirspaceLegs() {
+    return controlledAirspaceLegs;
+  }
+
+  Collection<ArincHelipad> helipads() {
+    return helipads;
+  }
+
+  Collection<ArincHeliport> heliports() {
+    return heliports;
+  }
+
+  Optional<ArincHeaderOne> headerOne() {
+    return headerOne;
+  }
+
+  /**
+   * Union the sources' records of one type, keeping the first record seen for each identity — so earlier (higher-precedence)
+   * sources shadow later ones, and a duplicated identity within one source keeps its first occurrence.
+   */
+  private static <T> Collection<T> mergeByIdentity(List<ConvertingArincRecordConsumer> ordered,
+      Function<ConvertingArincRecordConsumer, Collection<T>> records, Function<T, Object> identity) {
+
+    Map<Object, T> merged = new LinkedHashMap<>();
+    for (ConvertingArincRecordConsumer source : ordered) {
+      for (T record : records.apply(source)) {
+        merged.putIfAbsent(identity.apply(record), record);
+      }
+    }
+    return List.copyOf(merged.values());
+  }
+
+  private static Object airportIdentity(ArincAirport airport) {
+    return Arrays.asList(airport.airportIdentifier(), airport.airportIcaoRegion());
+  }
+
+  private static Object runwayIdentity(ArincRunway runway) {
+    return Arrays.asList(runway.airportIdentifier(), runway.airportIcaoRegion(), runway.runwayIdentifier());
+  }
+
+  private static Object localizerIdentity(ArincLocalizerGlideSlope localizer) {
+    return Arrays.asList(localizer.airportIdentifier(), localizer.airportIcaoRegion(),
+        localizer.localizerIdentifier(), localizer.runwayIdentifier());
+  }
+
+  private static Object ndbIdentity(ArincNdbNavaid ndb) {
+    return Arrays.asList(ndb.sectionCode(), ndb.subSectionCode().orElse(null),
+        ndb.airportIdentifier().orElse(null), ndb.ndbIdentifier(), ndb.ndbIcaoRegion());
+  }
+
+  private static Object vhfIdentity(ArincVhfNavaid vhf) {
+    return Arrays.asList(vhf.airportIdentifier().orElse(null), vhf.vhfIdentifier(), vhf.vhfIcaoRegion());
+  }
+
+  private static Object waypointIdentity(ArincWaypoint waypoint) {
+    return Arrays.asList(waypoint.sectionCode(), waypoint.subSectionCode().orElse(null),
+        waypoint.airportIdentifier().orElse(null), waypoint.waypointIdentifier(), waypoint.waypointIcaoRegion());
+  }
+
+  private static Object airwayLegIdentity(ArincAirwayLeg leg) {
+    return Arrays.asList(leg.routeIdentifier(), leg.sequenceNumber(), leg.fixIdentifier(), leg.fixIcaoRegion());
+  }
+
+  private static Object procedureLegIdentity(ArincProcedureLeg leg) {
+    return Arrays.asList(leg.airportIdentifier(), leg.airportIcaoRegion(), leg.subSectionCode().orElse(null),
+        leg.sidStarIdentifier(), leg.routeType(), leg.transitionIdentifier().orElse(null), leg.sequenceNumber());
+  }
+
+  private static Object glsIdentity(ArincGnssLandingSystem gls) {
+    return Arrays.asList(gls.airportIdentifier(), gls.airportIcaoRegion(),
+        gls.glsRefPathIdentifier(), gls.runwayIdentifier());
+  }
+
+  private static Object holdingPatternIdentity(ArincHoldingPattern holdingPattern) {
+    return Arrays.asList(holdingPattern.regionCode().orElse(null), holdingPattern.icaoRegion().orElse(null),
+        holdingPattern.fixIdentifier(), holdingPattern.fixIcaoRegion(),
+        holdingPattern.duplicateIdentifier().orElse(null));
+  }
+
+  private static Object firUirLegIdentity(ArincFirUirLeg leg) {
+    return Arrays.asList(leg.firUirIdentifier(), leg.firUirAddress().orElse(null),
+        leg.firUirIndicator(), leg.sequenceNumber());
+  }
+
+  private static Object controlledAirspaceLegIdentity(ArincControlledAirspaceLeg leg) {
+    return Arrays.asList(leg.icaoRegion(), leg.airspaceType(), leg.airspaceCenter(),
+        leg.multipleCode().orElse(null), leg.sequenceNumber());
+  }
+
+  private static Object helipadIdentity(ArincHelipad helipad) {
+    return Arrays.asList(helipad.airportHeliportIdentifier(), helipad.icaoCode(), helipad.helipadIdentifier());
+  }
+
+  private static Object heliportIdentity(ArincHeliport heliport) {
+    return Arrays.asList(heliport.heliportIdentifier(), heliport.heliportIcaoRegion(),
+        heliport.padIdentifier().orElse(null));
+  }
+}

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/ArincRecordParserTest.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/ArincRecordParserTest.java
@@ -24,6 +24,19 @@ class ArincRecordParserTest {
   }
 
   @Test
+  void testParserSkipsBlankAndTruncatedRecords() {
+
+    ArincRecordParser parser = ArincRecordParser.standard(
+        dummySpec(11, x -> true, new RecordField<>("field1", new BlankSpec(11)))
+    );
+
+    // shorter than every spec's record length (e.g. a stray blank line in a 424 file): the record
+    // cannot be column-parsed, so it is skipped per the optional-return contract rather than thrown on
+    assertEquals(Optional.empty(), parser.parse(""));
+    assertEquals(Optional.empty(), parser.parse("TRUNCATED"));
+  }
+
+  @Test
   void testParserWithConfiguredSpec() {
 
     ArincRecordParser parser = ArincRecordParser.standard(

--- a/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/OneshotRecordParserLayeredTest.java
+++ b/boogie-arinc/src/test/java/org/mitre/tdp/boogie/arinc/OneshotRecordParserLayeredTest.java
@@ -1,0 +1,156 @@
+package org.mitre.tdp.boogie.arinc;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mitre.tdp.boogie.Airport;
+import org.mitre.tdp.boogie.Airspace;
+import org.mitre.tdp.boogie.Airway;
+import org.mitre.tdp.boogie.Fix;
+import org.mitre.tdp.boogie.Heliport;
+import org.mitre.tdp.boogie.Leg;
+import org.mitre.tdp.boogie.Procedure;
+import org.mitre.tdp.boogie.Transition;
+
+/**
+ * {@link OneshotRecordParser#assembleFrom(List)}: several prioritized 424 sources assembled as one model — earlier sources win
+ * per record identity, records unique to any source are retained, and cross-source references resolve because the merge happens
+ * before assembly.
+ */
+class OneshotRecordParserLayeredTest {
+
+  private static final Path ARINC_TEST_FILE =
+      Path.of(System.getProperty("user.dir"), "src/test/resources/kjfk-and-friends.txt");
+
+  /** The KJFK ILS 04L final rides AROKE -> KRSTL -> RW04L; AROKE is a KJFK terminal (PC) waypoint at N40. */
+  private static final String AROKE_PREFIX = "SUSAP KJFKK6CAROKE";
+  private static final String I04L_PREFIX = "SUSAP KJFKK6FI04L";
+
+  private static List<String> base;
+  private static String aroke;
+
+  @BeforeAll
+  static void load() throws IOException {
+    base = Files.readAllLines(ARINC_TEST_FILE);
+    aroke = base.stream().filter(line -> line.startsWith(AROKE_PREFIX)).findFirst().orElseThrow();
+  }
+
+  private static InputStream streamOf(List<String> lines) {
+    return new ByteArrayInputStream(String.join("\n", lines).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static OneshotRecordParser.ClientRecords<Airport, Fix, Airway, Procedure, Airspace, Heliport> assemble(
+      List<InputStream> orderedSources) {
+    return OneshotRecordParser.standard(ArincVersion.V19).assembleFrom(orderedSources);
+  }
+
+  @Test
+  void earlierSourceWinsWhenRecordIdentityCollides() {
+    // the patch redefines the same waypoint identity (same airport/region/section/ident) a degree north
+    String patched = aroke.replace("N40282056", "N41282056");
+
+    List<Fix> arokes = assemble(List.of(streamOf(List.of(patched)), streamOf(base)))
+        .fixes().stream().filter(fix -> "AROKE".equals(fix.fixIdentifier())).toList();
+
+    assertAll(
+        () -> assertEquals(1, arokes.size(), "one AROKE survives the merge, not both versions"),
+        () -> assertEquals(41, (int) arokes.get(0).latitude(), "the earlier (patch) source's content wins")
+    );
+  }
+
+  @Test
+  void laterSourceIsShadowedNotMangled() {
+    // same two sources, base first: base's AROKE wins and the patch's version is dropped entirely
+    String patched = aroke.replace("N40282056", "N41282056");
+
+    List<Fix> arokes = assemble(List.of(streamOf(base), streamOf(List.of(patched))))
+        .fixes().stream().filter(fix -> "AROKE".equals(fix.fixIdentifier())).toList();
+
+    assertAll(
+        () -> assertEquals(1, arokes.size()),
+        () -> assertEquals(40, (int) arokes.get(0).latitude(), "base wins when it is the earlier source")
+    );
+  }
+
+  @Test
+  void recordsUniqueToAnySourceAreAllRetained() {
+    // an additive overlay: a waypoint identity the base does not define (the LBG-SPA.dat use case —
+    // a decommissioned navaid still filed in routes, re-added on top of the current cycle)
+    String added = aroke.replace("AROKE", "AROKX");
+
+    var merged = assemble(List.of(streamOf(List.of(added)), streamOf(base)));
+    Set<String> idents = merged.fixes().stream().map(Fix::fixIdentifier).collect(toSet());
+
+    assertAll(
+        () -> assertTrue(idents.contains("AROKX"), "overlay-only record present"),
+        () -> assertTrue(idents.contains("AROKE"), "base records all present")
+    );
+  }
+
+  @Test
+  void crossSourceReferencesResolveBecauseMergeHappensBeforeAssembly() {
+    // split the ILS 04L legs into their own source: its legs reference fixes (AROKE, KRSTL), the
+    // localizer, and the runway (RW04L) that only the base source defines — assembled per-source the
+    // procedure would come out with dangling references; merged-then-assembled it is complete
+    List<String> approachOnly = base.stream().filter(line -> line.startsWith(I04L_PREFIX)).toList();
+    List<String> baseWithoutApproach = base.stream().filter(line -> !line.startsWith(I04L_PREFIX)).toList();
+    assertTrue(!approachOnly.isEmpty(), "fixture still carries the I04L approach");
+
+    var merged = assemble(List.of(streamOf(approachOnly), streamOf(baseWithoutApproach)));
+
+    Procedure i04l = merged.procedures().stream()
+        .filter(procedure -> "I04L".equals(procedure.procedureIdentifier())
+            && "KJFK".equals(procedure.airportIdentifier()))
+        .findFirst().orElseThrow();
+
+    Set<String> boundFixes = i04l.transitions().stream()
+        .map(Transition::legs).flatMap(List::stream)
+        .map(Leg::associatedFix).flatMap(Optional::stream)
+        .map(Fix::fixIdentifier)
+        .collect(toSet());
+
+    assertTrue(boundFixes.containsAll(Set.of("AROKE", "KRSTL", "RW04L")),
+        "approach legs bind fixes and the runway defined only in the base source, got: " + boundFixes);
+  }
+
+  @Test
+  void singleSourceListMatchesSingleStreamAssembly() throws IOException {
+    var single = OneshotRecordParser.standard(ArincVersion.V19)
+        .assembleFrom(Files.newInputStream(ARINC_TEST_FILE));
+    var listOfOne = assemble(List.of(streamOf(base)));
+
+    assertAll(
+        () -> assertEquals(single.airports().size(), listOfOne.airports().size(), "Airports"),
+        () -> assertEquals(single.fixes().size(), listOfOne.fixes().size(), "Fixes"),
+        () -> assertEquals(single.airways().size(), listOfOne.airways().size(), "Airways"),
+        () -> assertEquals(single.procedures().size(), listOfOne.procedures().size(), "Procedures"),
+        () -> assertEquals(single.firUirs().size(), listOfOne.firUirs().size(), "FIR-UIRs"),
+        () -> assertEquals(single.heliports().size(), listOfOne.heliports().size(), "Heliports")
+    );
+  }
+
+  @Test
+  void emptySourceListYieldsEmptyClientRecords() {
+    var merged = assemble(List.of());
+
+    assertAll(
+        () -> assertEquals(0, merged.airports().size()),
+        () -> assertEquals(0, merged.fixes().size()),
+        () -> assertEquals(0, merged.procedures().size())
+    );
+  }
+}


### PR DESCRIPTION
## What

`OneshotRecordParser.assembleFrom(List<InputStream>)` — assemble one navigation model from **several prioritized 424 sources**. Sources earlier in the list win; records unique to any source are retained; the merge happens **before** assembly so cross-source references resolve.

```java
OneshotRecordParser.standard(ArincVersion.V19)
    .assembleFrom(List.of(patchFileStream, publishedCycleStream));
```

## Why

Consumers layer 424 data: a hand-built patch/overlay file on top of a published cycle (re-adding a decommissioned navaid still filed in routes, patching one airport's records for a study), or — increasingly — local overrides on top of a **database-served subset** of a cycle. Akela solves this with per-source prioritized fetchers resolved lazily at lookup time. `OneshotRecordParser` binds references **eagerly at assembly** (legs → fixes against the stream's fix database), which is exactly why the layering mechanism has to live here: per-source assembly leaves a patch source's procedures with dangling references, and consumers can't merge converted records themselves without reaching into the `ConvertingArincRecordConsumer`/mapper path that's slated for deletion.

What consumers do today instead is concatenate files into one stream — which is subtly wrong twice over:
1. **Priority breaks on patches.** The consumer's `LinkedHashSet` de-dupes on *exact equality*, so a record redefined with different content survives **twice**, and which version wins is decided by downstream database keying order — not by the declared layering.
2. A separator `\n` after a newline-terminated file becomes a **blank line**, which threw `StringIndexOutOfBoundsException: Index 4 out of bounds for length 0` from the spec's column reads (this took down every multi-file phao scenario last week).

## Design

- **Precedence is per record identity** — the ARINC spec key fields of each converted type (e.g. `(airport, region, runway)` for a runway; `(airport, region, subsection, procedure, route type, transition, sequence)` for a procedure leg). A later source is shadowed record-by-record, never half-merged by content.
- **Merge, then assemble once**: one fix/terminal-area database over the merged records, so a patch source's legs bind fixes/navaids/runways defined only in the base.
- **Layering policy stays with the consumer** (what the sources are, their order); this adds only the mechanism boogie's eager assembly makes boogie's to own.
- **`assembleFrom(InputStream)` is behaviorally untouched** — refactored to share the assembly tail through a pass-through; the existing fixture test (`OneshotRecordParserTest`, exact counts) passes unchanged.
- Header (`ClientRecords.headerOne`): first one present in source order.

## Also: parser hardening (first commit)

`ArincRecordParser.Standard` now skips lines shorter than every spec's record length (a stray blank or truncated line in a file) instead of throwing from the spec's substring reads — the interface already documents the optional-return contract for unparseable records. Behavior change: such lines previously crashed the parse; now they're ignored.

## Tests

`OneshotRecordParserLayeredTest` (runs against the in-repo `kjfk-and-friends.txt` fixture):
- patch precedence both orders (same waypoint identity, moved 1° — earlier source's content wins, exactly one survives)
- additive overlay records retained alongside the base
- **cross-source binding**: the KJFK ILS 04L legs split into their own source still assemble complete, binding `AROKE`/`KRSTL`/`RW04L` from the base source
- single-element list ≡ single-stream assembly (same counts)
- empty list → empty `ClientRecords`

Plus blank/truncated-line cases in `ArincRecordParserTest`.

Full build green except the `boogie-dafif`/Lido integration tests that require licensed local data files (`DAFIF8_1_2601.zip`, `A424-22std.dat.gz`) — those fail identically on unmodified `main` in a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)