### PR TITLE
VM/FM Weight Changes

### DIFF
--- a/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/score/legtype/FmFeatureScorer.java
+++ b/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/score/legtype/FmFeatureScorer.java
@@ -17,8 +17,8 @@ public final class FmFeatureScorer implements ViterbiFeatureVectorScorer {
 
   public FmFeatureScorer() {
     this(
-        simpleLogistic(15., 30.),
-        simpleLogistic(15., 25.),
+        simpleLogistic(5., 10.),
+        simpleLogistic(10., 20.),
         (d) -> d < 0.0 ? 0.0 : 1.0,
         (d) -> d > 0.5 ? 0.0 : 1.0
     );

--- a/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/score/legtype/VmFeatureScorer.java
+++ b/boogie-conformance/src/main/java/org/mitre/tdp/boogie/conformance/alg/assign/score/legtype/VmFeatureScorer.java
@@ -16,7 +16,7 @@ public final class VmFeatureScorer implements ViterbiFeatureVectorScorer {
 
   public VmFeatureScorer() {
     this(
-        simpleLogistic(15., 30.),
+        simpleLogistic(5., 10.),
         simpleLogistic(10., 20.)
     );
   }


### PR DESCRIPTION
These are the numbers that worked better in TDP.

The effect is that it will still give an above floor score for flying the route, but e.g., if a TF leg over the same space was there the TF will score higher.  This Allows: TF(FIX) -> IF(FIX) combos to score higher (when combined with the skip link class already there) over TF(FIX) -> FM(FIX) -> IF(FIX) when the airplane clearly just kept flying straight through and the manual operation was skipped,

